### PR TITLE
TXM-910 Fix performance bug in auditing filter

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/audit/AuditExtensions.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/AuditExtensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/EventKeys.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/EventKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/EventTypes.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/EventTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/filters/AuditFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/filters/AuditFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/filters/AuditFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/filters/AuditFilter.scala
@@ -25,9 +25,10 @@ import uk.gov.hmrc.play.audit.http.HttpAuditEvent
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, Auditor}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Promise, Future}
+import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 trait AuditFilter extends EssentialFilter with HttpAuditEvent {
@@ -47,24 +48,24 @@ trait AuditFilter extends EssentialFilter with HttpAuditEvent {
   }
 
   protected def captureRequestBody(next: Iteratee[Array[Byte], Result], onDone: Promise[Array[Byte]]): Iteratee[Array[Byte], Result] = {
-    def step(body: Array[Byte], nextI: Iteratee[Array[Byte], Result])(input: Input[Array[Byte]]): Iteratee[Array[Byte], Result] = {
+    def step(body: mutable.ArrayBuffer[Byte], nextI: Iteratee[Array[Byte], Result])(input: Input[Array[Byte]]): Iteratee[Array[Byte], Result] = {
       input match {
-        case Input.El(e) => Cont[Array[Byte], Result](step(Array.concat(body, e), Iteratee.flatten(nextI.feed(Input.El(e)))))
+        case Input.El(e) => Cont[Array[Byte], Result](step(body ++= e, Iteratee.flatten(nextI.feed(Input.El(e)))))
         case Input.Empty => Cont[Array[Byte], Result](step(body, nextI))
         case Input.EOF => {
           val result = Iteratee.flatten(nextI.feed(Input.EOF))
-          onDone.success(body)
+          onDone.success(body.toArray)
           result
         }
       }
     }
 
-    Cont[Array[Byte], Result](i => step(Array(), next)(i))
+    Cont[Array[Byte], Result](i => step(new ArrayBuffer[Byte](1024), next)(i))
   }
 
   protected def captureResult(next: Iteratee[Array[Byte], Result], requestBody: Future[Array[Byte]])(handler: (Array[Byte], Try[Result]) => Unit): Iteratee[Array[Byte], Result] = {
     next.map { result =>
-      val collectedBody = new ArrayBuffer[Byte](0)
+      val collectedBody = new mutable.ArrayBuffer[Byte](1024)
 
       def collect(i: Array[Byte]) = { collectedBody.appendAll(i); i }
       def handleSuccess() = requestBody.onSuccess { case body =>

--- a/src/main/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditEvent.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/config/ErrorAuditingSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/config/ErrorAuditingSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/model/Audit.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/model/Audit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceFingerprint.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceFingerprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceId.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/filters/AuditFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/filters/AuditFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/filters/FilterFlowMock.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/filters/FilterFlowMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/ErrorAuditingSettingsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/ErrorAuditingSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditEventSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditEventSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/connector/MockAuditConnector.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/connector/MockAuditConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/audit/model/DeviceIdSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/model/DeviceIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/test/AssetsTestController.scala
+++ b/src/test/scala/uk/gov/hmrc/play/test/AssetsTestController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/test/DummyHttpResponse.scala
+++ b/src/test/scala/uk/gov/hmrc/play/test/DummyHttpResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/test/DummyRequestHeader.scala
+++ b/src/test/scala/uk/gov/hmrc/play/test/DummyRequestHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
+++ b/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Using `Array.concat` was causing bigger and bigger objects to be continually allocated from the heap, causing Heap Allocation Failures and forcing GC. This was happening every time a request body was audited!
* The new solution uses `ArrayBuffer` with a reasonably allocated initial size to avoid unnecessary futher allocations