### PR TITLE
Swapped keys in AuditEventFailureKeys trait

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -30,8 +30,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait AuditEventFailureKeys {
   private val EventMissed = "DS_EventMissed"
-  val LoggingAuditRequestFailureKey : String = EventMissed + "_AuditFailureResponse"
-  val LoggingAuditFailureResponseKey : String = EventMissed + "_AuditRequestFailure"
+  val LoggingAuditFailureResponseKey : String = EventMissed + "_AuditFailureResponse"
+  val LoggingAuditRequestFailureKey : String = EventMissed + "_AuditRequestFailure"
 }
 
 object AuditEventFailureKeys extends AuditEventFailureKeys

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -246,11 +246,13 @@ class AuditConnectorSpec extends WordSpecLike with MustMatchers with ScalaFuture
 
   private def checkAuditRequestFailureMessage(message: String, body: JsValue) {
     message must startWith(AuditEventFailureKeys.LoggingAuditRequestFailureKey)
+    message must include("_AuditRequestFailure")
     message must include(body.toString)
   }
 
   private def checkAuditFailureMessage(message: String, body: JsValue, code: Int) {
     message must startWith(AuditEventFailureKeys.LoggingAuditFailureResponseKey)
+    message must include("_AuditFailureResponse")
     message must include(body.toString)
     message must include(code.toString)
   }


### PR DESCRIPTION
I've realised reading at my logs that the message wasn't correct, and I found this small issue on those two keys which are swapped.
The test wasn't checking the content of the message, therefore was passing (was comparing the wrong message expecting it to be the wrong one again).
I've added a condition on the test itself to - partially - inspect the content.