### PR TITLE
TXM-1805 Simplify domain name match regexp.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
@@ -35,7 +35,7 @@ trait HttpAuditing extends DateTimeUtils {
 
   def auditConnector: AuditConnector
   def appName: String
-  def auditDisabledForPattern: Regex = """http(s)?:\/\/.*\.(service|public\.mdtp|protected\.mdtp|private\.mdtp)($|[:\/])""".r
+  def auditDisabledForPattern: Regex = """http(s)?:\/\/.*\.(service|mdtp)($|[:\/])""".r
 
   object AuditingHook extends HttpHook {
     override def apply(url: String, verb: String, body: Option[_], responseF: Future[HttpResponse])(implicit hc: HeaderCarrier): Unit = {

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
@@ -237,7 +237,7 @@ class HttpAuditingSpec extends WordSpecLike with Matchers with Inspectors with E
   }
 
   "Calling an internal microservice" should {
-    val auditUris = Seq("service", "public.mdtp", "protected.mdtp", "private.mdtp").map { zone =>
+    val auditUris = Seq("service", "public.mdtp", "protected.mdtp", "private.mdtp", "monolith.mdtp", "foobar.mdtp", "mdtp").map { zone =>
       s"http://auth.$zone:80/auth/authority"
     }
     val getVerb = "GET"


### PR DESCRIPTION
Now match `mdtp` as top level and any subdomain as well.