### PR TITLE
Removed dangerous debug of audit event

### DIFF
--- a/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
+++ b/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
@@ -40,7 +40,7 @@ abstract class HttpHandler(endpointUrl: URL, connectTimeout: Integer = 5000,
 
     try {
       if (event != null && event.length > 0) {
-        logger.debug(s"Sending request to URL ${endpointUrl.toString} : $event")
+        logger.debug(s"Sending audit request to URL ${endpointUrl.toString}")
 
         try {
           val connection = getConnection


### PR DESCRIPTION
If you happen to be debugging an app in Production then this will dump all your audit data into the logs. This PR removes the event from the debug.