### PR TITLE
[TR] TXM-3316 set user-agent

### DIFF
--- a/src/main/scala/uk/gov/hmrc/audit/handler/DatastreamHandler.scala
+++ b/src/main/scala/uk/gov/hmrc/audit/handler/DatastreamHandler.scala
@@ -22,8 +22,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.hmrc.audit.HandlerResult
 import uk.gov.hmrc.audit.HandlerResult.{Failure, Rejected, Success}
 
-class DatastreamHandler(scheme: String, host: String, port: Integer, path: String, connectTimeout: Integer, requestTimeout: Integer)
-  extends HttpHandler(new URL(s"$scheme://$host:$port$path"), connectTimeout, requestTimeout)
+class DatastreamHandler(scheme: String, host: String, port: Integer, path: String, connectTimeout: Integer, requestTimeout: Integer, userAgent:String)
+  extends HttpHandler(new URL(s"$scheme://$host:$port$path"), userAgent, connectTimeout, requestTimeout)
     with AuditHandler {
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
+++ b/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
@@ -28,7 +28,7 @@ object HttpResult {
   case class Failure(msg: String, nested: Option[Throwable] = None) extends Exception(msg, nested.orNull) with HttpResult
 }
 
-abstract class HttpHandler(endpointUrl: URL, connectTimeout: Integer = 5000,
+abstract class HttpHandler(endpointUrl: URL, userAgent:String, connectTimeout: Integer = 5000,
     requestTimeout: Integer = 5000, contentTypeHeader: String = "application/json",
     acceptHeader: String = "application/json") {
   
@@ -99,6 +99,7 @@ abstract class HttpHandler(endpointUrl: URL, connectTimeout: Integer = 5000,
     connection.setRequestMethod("POST")
     connection.setRequestProperty("Content-Type", contentTypeHeader)
     connection.setRequestProperty("Accept", acceptHeader)
+    connection.setRequestProperty("User-Agent", userAgent)
     connection.setConnectTimeout(connectTimeout)
     connection.setReadTimeout(requestTimeout)
     connection.setDoOutput(true)

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -59,10 +59,10 @@ trait AuditConnector {
   lazy val baseUri: BaseUri = consumer.baseUri
 
   def simpleDatastreamHandler: AuditHandler = new DatastreamHandler(baseUri.protocol, baseUri.host,
-    baseUri.port, s"/${consumer.singleEventUri}", defaultConnectionTimeout, defaultRequestTimeout)
+    baseUri.port, s"/${consumer.singleEventUri}", defaultConnectionTimeout, defaultRequestTimeout, auditingConfig.auditSource)
 
   def mergedDatastreamHandler: AuditHandler = new DatastreamHandler(baseUri.protocol, baseUri.host,
-    baseUri.port, s"/${consumer.mergedEventUri}", defaultConnectionTimeout, defaultRequestTimeout)
+    baseUri.port, s"/${consumer.mergedEventUri}", defaultConnectionTimeout, defaultRequestTimeout, auditingConfig.auditSource)
 
   def loggingConnector: AuditHandler = LoggingHandler
   def auditSerialiser: AuditSerialiserLike = AuditSerialiser


### PR DESCRIPTION
Sets the user-agent when making calls to datastream.

This is needed when diagnosing issues as kibana shows the user-agent value.

This would have been set automatically when http-verbs was used
for the call to datastream. http-verbs was removed to remove the
dependency on play-framework, and the user-agent was not explicity set.