### PR TITLE
PLATOPS-1619: upgrade to Play 2.5.19

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -25,7 +25,7 @@ private object AppDependencies {
     ),
     play25 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.5",
-      "uk.gov.hmrc" %% "http-verbs" % "8.8.0-play-25"
+      "uk.gov.hmrc" %% "http-verbs" % "8.10.0-play-25-SNAPSHOT"
     ),
     play26 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.25",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -25,7 +25,7 @@ private object AppDependencies {
     ),
     play25 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.5",
-      "uk.gov.hmrc" %% "http-verbs" % "8.10.0-play-25-SNAPSHOT"
+      "uk.gov.hmrc" %% "http-verbs" % "8.10.0-play-25"
     ),
     play26 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.25",


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.  