### PR TITLE
Cross build and code compatibility with scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 
 sudo: false
 language: scala
-scala:
-- 2.11.6
-jdk:
-- oraclejdk8
+matrix:
+  include:
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.5
+      jdk: oraclejdk8
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.6
+      jdk: oraclejdk8
+    - scala: 2.12.8
+      env: PLAY_VERSION=2.6
+      jdk: oraclejdk8
 cache:
   directories:
     - '$HOME/.ivy2/cache'

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val library: Project = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
     makePublicallyAvailableOnBintray := true,
-    majorVersion                     := 3
+    majorVersion                     := 4
   )
   .settings(
     name := "play-auditing",
@@ -32,6 +32,7 @@ lazy val library: Project = (project in file("."))
     scalacOptions ++= Seq("-language:implicitConversions"),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalaVersion := "2.11.12",
+    crossScalaVersions := List("2.11.12", "2.12.8"),
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.typesafeRepo("releases")

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,15 +21,15 @@ private object AppDependencies {
 
   val compile = dependencies(
     shared = Seq(
-      "uk.gov.hmrc" %% "time"       % "3.2.0"
+      "uk.gov.hmrc" %% "time"       % "3.3.0"
     ),
     play25 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.5",
-      "uk.gov.hmrc" %% "http-verbs" % "9.0.0-play-25"
+      "uk.gov.hmrc" %% "http-verbs" % "9.3.0-play-25"
     ),
     play26 = Seq(
       "org.slf4j"   % "slf4j-api"   % "1.7.25",
-      "uk.gov.hmrc" %% "http-verbs" % "9.0.0-play-26"
+      "uk.gov.hmrc" %% "http-verbs" % "9.3.0-play-26"
     )
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.version=0.13.11
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.15.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.11.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.13.0")

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.http.hooks.HttpHook
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.time.DateTimeUtils
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.matching.Regex
 
@@ -50,12 +49,12 @@ trait HttpAuditing extends DateTimeUtils {
     }
   }
 
-  def auditFromPlayFrontend(url: String, response: HttpResponse, hc: HeaderCarrier): Unit = audit(HttpRequest(url, "", None, now), response)(hc)
+  def auditFromPlayFrontend(url: String, response: HttpResponse, hc: HeaderCarrier)(implicit ec: ExecutionContext): Unit = audit(HttpRequest(url, "", None, now), response)(hc, ec)
 
-  private[http] def audit(request: HttpRequest, responseToAudit: HttpResponse)(implicit hc: HeaderCarrier): Unit =
+  private[http] def audit(request: HttpRequest, responseToAudit: HttpResponse)(implicit hc: HeaderCarrier, ex: ExecutionContext): Unit =
     if (isAuditable(request.url)) auditConnector.sendMergedEvent(dataEventFor(request, responseToAudit))
 
-  private[http] def auditRequestWithException(request: HttpRequest, errorMessage: String)(implicit hc: HeaderCarrier): Unit =
+  private[http] def auditRequestWithException(request: HttpRequest, errorMessage: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Unit =
     if (isAuditable(request.url)) auditConnector.sendMergedEvent(dataEventFor(request, errorMessage))
 
   private def dataEventFor(request: HttpRequest, errorMesssage: String)(implicit hc: HeaderCarrier) = {


### PR DESCRIPTION
This has breaking change in API - reasony why major was increase.
Method `auditFromPlayFrontend` now require implicit execution context.
This allow to remove global ExecutionContext from HttpAuditing.

Depends on https://github.com/hmrc/sbt-play-cross-compilation/pull/1