### PR TITLE
DLK-762 Fix final counter metric

### DIFF
--- a/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditMetric.scala
+++ b/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditMetric.scala
@@ -21,5 +21,5 @@ package uk.gov.hmrc.play.audit.http.connector
 // This indirection is needed because the play metrics library is specific to the play version
 
 trait AuditCounterMetrics {
-  def registerMetric(name:String, read:()=>Long):Unit
+  def registerMetric(name:String, read:()=>Option[Long]):Unit
 }


### PR DESCRIPTION
Works around a bug in the MDTP metrics which causes the metrics published at shutdown
to be averaged with any scheduled publication values.

This change insures that the correct final count is published and will never be averaged
with other values as it it not published until the value is known.