### PR TITLE
DLK-714 publish audit counters to stdout

### DIFF
--- a/src-common/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/src-common/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -50,5 +50,6 @@ case class AuditingConfig(
   consumer   : Option[Consumer],
   enabled    : Boolean,
   auditSource: String,
-  auditSentHeaders: Boolean
+  auditSentHeaders: Boolean,
+  publishCountersToStdOut: Boolean
 )

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
@@ -55,7 +55,7 @@ class AuditChannelSpec
     "post data to datastream" in {
       val testPort = WireMockUtils.availablePort
       val consumer = Consumer(BaseUri("localhost", testPort, "http"))
-      val config = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false)
+      val config = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false, publishCountersToStdOut = false)
       val channel = new AuditChannel {
         override def auditingConfig: AuditingConfig = config
 

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -55,7 +55,7 @@ class AuditConnectorSpec
   implicit val m: Materializer      = ActorMaterializer()//required for play 2.6
 
   private val consumer = Consumer(BaseUri("datastream-base-url", 8080, "http"))
-  private val enabledConfig = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false)
+  private val enabledConfig = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false, publishCountersToStdOut = false)
 
   private val mockAuditChannel: AuditChannel = mock[AuditChannel]
 
@@ -118,7 +118,8 @@ class AuditConnectorSpec
         consumer    = Some(Consumer(BaseUri("datastream-base-url", 8080, "http"))),
         enabled     = false,
         auditSource = "the-project-name",
-        auditSentHeaders = false
+        auditSentHeaders = false,
+        publishCountersToStdOut = false
       )
 
       createConnector(disabledConfig).sendEvent(event).futureValue must be(AuditResult.Disabled)

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
@@ -67,7 +67,8 @@ class AuditSpec extends AnyWordSpecLike with Matchers with Eventually {
       consumer = Some(Consumer(BaseUri("localhost", 11111, "http"))),
       enabled = true,
       auditSource = "the-project-name",
-      auditSentHeaders = false
+      auditSentHeaders = false,
+      publishCountersToStdOut = true
     )
     val testmaterializer = ActorMaterializer()(ActorSystem())
     new AuditConnector {


### PR DESCRIPTION
Publishing audit counters using slf4j logging only works if the logging level is correct

In practise most microservices have their root log level set to WARN in production

Global property overrides are possible, but log levels can only be changed on a per-logger
basis if every microservice defines the logger and reads the system property

The least worst option is to write the counters directly to std out.
The message is written using similar json to the default HMRC JsonEncoder so that app, logger,
timestamp & message are parsed.
The logger is named play-auditing to help identify the source of the log message