### PR TITLE
DLK-714 Move audit counter logging to bootstrap-play

### DIFF
--- a/src-common/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/src-common/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -50,5 +50,6 @@ case class AuditingConfig(
   consumer   : Option[Consumer],
   enabled    : Boolean,
   auditSource: String,
-  auditSentHeaders: Boolean
+  auditSentHeaders: Boolean,
+  publishCountersToLogs: Boolean
 )

--- a/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounter.scala
+++ b/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounter.scala
@@ -38,6 +38,7 @@ private[connector] trait UnpublishedAuditCounter extends AuditCounter {
   def auditingConfig: AuditingConfig
   def auditChannel: AuditChannel
   def auditMetrics: AuditCounterMetrics
+  def auditCounterLogs: AuditCounterLogs
 
   protected val logger: Logger = LoggerFactory.getLogger("auditCounter")
   private val instanceID = UUID.randomUUID().toString
@@ -77,7 +78,9 @@ private[connector] trait UnpublishedAuditCounter extends AuditCounter {
       if (isFinal) {
         finalSequence.set(Some(currentSequence))
       }
-      logger.info(s"AuditCounter: $auditCount")
+      if (auditingConfig.publishCountersToLogs) {
+        auditCounterLogs.logInfo(s"AuditCounter: $auditCount")
+      }
       auditChannel.send("/write/audit", auditCount)(ec).map(_ => Done)(ec)
     } else {
       Future.successful(Done)
@@ -98,6 +101,7 @@ private[connector] trait UnpublishedAuditCounter extends AuditCounter {
   }
 
   protected def currentTime() = Instant.now
+
   private def timestamp(): String = {
     DateTimeFormatter
       .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")

--- a/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounterLogs.scala
+++ b/src-common/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounterLogs.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.connector
+
+/*
+ * A trait to move the logging to bootstrap-play because play-auditing does not
+ * have access to the specific logging classes to ensure that info logs are not suppressed
+ */
+trait AuditCounterLogs {
+  def logInfo(message: String)
+}

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
@@ -55,7 +55,7 @@ class AuditChannelSpec
     "post data to datastream" in {
       val testPort = WireMockUtils.availablePort
       val consumer = Consumer(BaseUri("localhost", testPort, "http"))
-      val config = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false)
+      val config = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false, publishCountersToLogs = false)
       val channel = new AuditChannel {
         override def auditingConfig: AuditingConfig = config
 

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -55,7 +55,7 @@ class AuditConnectorSpec
   implicit val m: Materializer      = ActorMaterializer()//required for play 2.6
 
   private val consumer = Consumer(BaseUri("datastream-base-url", 8080, "http"))
-  private val enabledConfig = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false)
+  private val enabledConfig = AuditingConfig(consumer = Some(consumer), enabled = true, auditSource = "the-project-name", auditSentHeaders = false, publishCountersToLogs = false)
 
   private val mockAuditChannel: AuditChannel = mock[AuditChannel]
 
@@ -118,7 +118,8 @@ class AuditConnectorSpec
         consumer    = Some(Consumer(BaseUri("datastream-base-url", 8080, "http"))),
         enabled     = false,
         auditSource = "the-project-name",
-        auditSentHeaders = false
+        auditSentHeaders = false,
+        publishCountersToLogs = false
       )
 
       createConnector(disabledConfig).sendEvent(event).futureValue must be(AuditResult.Disabled)

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounterSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditCounterSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.play.audit.http.connector
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{verify, when, verifyNoInteractions}
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
@@ -48,6 +48,8 @@ class AuditCounterSpec
     val stubAuditChannel = mock[AuditChannel]
     when(stubAuditChannel.send(any[String], any[JsValue])(any[ExecutionContext])).thenReturn(Future.successful(Success))
 
+    val stubAuditCounterLogs = mock[AuditCounterLogs]
+
     val stubLogger = mock[Logger]
 
     var metrics = Map.empty[String,()=>Option[Long]]
@@ -59,9 +61,10 @@ class AuditCounterSpec
 
     def createCounter(enabled: Boolean = true) = {
       new UnpublishedAuditCounter {
-        override def auditingConfig = AuditingConfig(None, enabled, "projectname", false)
+        override def auditingConfig = AuditingConfig(None, enabled, "projectname", false, true)
         override def auditChannel = stubAuditChannel
         override def auditMetrics = stubAuditMetrics
+        override def auditCounterLogs = stubAuditCounterLogs
         override val logger = stubLogger
       }
     }
@@ -104,9 +107,10 @@ class AuditCounterSpec
       val time = LocalDateTime.of(2021, 2, 2, 12, 0, 0).toInstant(ZoneOffset.of("Z"))
 
       val counter = new UnpublishedAuditCounter {
-        override def auditingConfig = AuditingConfig(None, true, "projectname", false)
+        override def auditingConfig = AuditingConfig(None, true, "projectname", false, true)
         override def auditChannel = stubAuditChannel
         override def auditMetrics = stubAuditMetrics
+        override def auditCounterLogs: AuditCounterLogs = stubAuditCounterLogs
         override def currentTime() = time
       }
 
@@ -138,6 +142,24 @@ class AuditCounterSpec
 
       (1 to 10).map(_ =>  counter.createMetadata())
       metrics.isEmpty mustBe true
+    }
+
+    "publish the counters logs" in new Test {
+      val counter = createCounter()
+      counter.publish(isFinal = false)
+      verify(stubAuditCounterLogs).logInfo(any[String])
+    }
+
+    "not publish the counters to std out when disabled" in new Test {
+      val counter = new UnpublishedAuditCounter {
+        override def auditingConfig = AuditingConfig(None, true, "projectname", false, publishCountersToLogs = false)
+        override def auditChannel = stubAuditChannel
+        override def auditMetrics = stubAuditMetrics
+        override def auditCounterLogs = stubAuditCounterLogs
+      }
+      counter.publish(isFinal=false)
+
+      verifyNoInteractions(stubAuditCounterLogs)
     }
 
     "warn if a final audit event has already been sent" in new Test {

--- a/src-common/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
@@ -67,7 +67,8 @@ class AuditSpec extends AnyWordSpecLike with Matchers with Eventually {
       consumer = Some(Consumer(BaseUri("localhost", 11111, "http"))),
       enabled = true,
       auditSource = "the-project-name",
-      auditSentHeaders = false
+      auditSentHeaders = false,
+      publishCountersToLogs = true
     )
     val testmaterializer = ActorMaterializer()(ActorSystem())
     new AuditConnector {


### PR DESCRIPTION
Using the default logging api to publish audit counters via logs only works
if services have set the log level to info.

By moving the logging code into bootstrap-play we can ensure that
audit counter logs are always emmitted because bootstrap-play has
access to the logging implementation classes