### PR TITLE
dlk-855: removing old publishing hook

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ lazy val library = (project in file("."))
   .settings(
     commonSettings,
     publish := {},
-    publishAndDistribute := {},
     // by default this is Seq(scalaVersion) which doesn't play well and causes sbt
     // to try an invalid cross-build for playAuditingPlay25
     crossScalaVersions := Seq.empty


### PR DESCRIPTION
@konradwudkowski 's advised this is an old setting. 

I've tested this by running a HOTFIX build from this branch which succeeded: https://build.tax.service.gov.uk/job/TXM/job/play-auditing/32/console