### PR TITLE
CCIT-1231: Add auditProvider attribute to audit model

### DIFF
--- a/play-auditing-play-30/src/main/resources/reference.conf
+++ b/play-auditing-play-30/src/main/resources/reference.conf
@@ -15,4 +15,5 @@
 auditing {
   enabled          = true
   auditSentHeaders = false
+  auditProvider    = null
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiser.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiser.scala
@@ -67,7 +67,8 @@ class AuditSerialiser extends AuditSerialiserLike {
     }
 
   private implicit val dataEventWriter: Writes[DataEvent] =
-    ( (__ \ "auditSource"                ).write[String]
+    ( (__ \ "auditProvider"              ).writeNullable[String]
+    ~ (__ \ "auditSource"                ).write[String]
     ~ (__ \ "auditType"                  ).write[String]
     ~ (__ \ "eventId"                    ).write[String]
     ~ (__ \ "tags"                       ).write[Map[String, String]]
@@ -75,10 +76,11 @@ class AuditSerialiser extends AuditSerialiserLike {
     ~ (__ \ "generatedAt"                ).write[Instant]
     ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
     ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
+    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
 
   private implicit val extendedDataEventWriter: Writes[ExtendedDataEvent] =
-    ( (__ \ "auditSource"                ).write[String]
+    ( (__ \ "auditProvider"              ).writeNullable[String]
+    ~ (__ \ "auditSource"                ).write[String]
     ~ (__ \ "auditType"                  ).write[String]
     ~ (__ \ "eventId"                    ).write[String]
     ~ (__ \ "tags"                       ).write[Map[String, String]]
@@ -86,7 +88,7 @@ class AuditSerialiser extends AuditSerialiserLike {
     ~ (__ \ "generatedAt"                ).write[Instant]
     ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
     ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
+    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
 
   private implicit val dataCallWriter: Writes[DataCall] =
     ( (__ \ "tags"       ).write[Map[String, String]]
@@ -95,14 +97,15 @@ class AuditSerialiser extends AuditSerialiserLike {
     )(dc => (dc.tags, dc.detail, dc.generatedAt))
 
   private implicit val mergedDataEventWriter  : Writes[MergedDataEvent]   =
-    ( (__ \ "auditSource"                ).write[String]
+    ( (__ \ "auditProvider"              ).writeNullable[String]
+    ~ (__ \ "auditSource"                ).write[String]
     ~ (__ \ "auditType"                  ).write[String]
     ~ (__ \ "eventId"                    ).write[String]
     ~ (__ \ "request"                    ).write[DataCall]
     ~ (__ \ "response"                   ).write[DataCall]
     ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
     ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditSource, de.auditType, de.eventId, de.request, de.response, de.truncationLog, de.redactionLog))
+    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.request, de.response, de.truncationLog, de.redactionLog))
 
 
   override def serialise(event: DataEvent): JsObject =

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -50,7 +50,8 @@ case class AuditingConfig(
   consumer        : Option[Consumer],
   enabled         : Boolean,
   auditSource     : String,
-  auditSentHeaders: Boolean
+  auditSentHeaders: Boolean,
+  auditProvider   : Option[String] = None
 )
 
 object AuditingConfig {
@@ -68,7 +69,8 @@ object AuditingConfig {
                               )
                             ),
         auditSource       = configuration.get[String]("appName"),
-        auditSentHeaders  = configuration.get[Boolean]("auditing.auditSentHeaders")
+        auditSentHeaders  = configuration.get[Boolean]("auditing.auditSentHeaders"),
+        auditProvider     = configuration.getOptional[String]("auditing.auditProvider")
       )
     else
       AuditingConfig(

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -70,7 +70,7 @@ object AuditingConfig {
                             ),
         auditSource       = configuration.get[String]("appName"),
         auditSentHeaders  = configuration.get[Boolean]("auditing.auditSentHeaders"),
-        auditProvider     = configuration.getOptional[String]("auditing.auditProvider")
+        auditProvider     = configuration.get[Option[String]]("auditing.auditProvider")
       )
     else
       AuditingConfig(

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -63,11 +63,12 @@ trait AuditConnector {
   def sendExplicitAudit(auditType: String, detail: JsObject)(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit =
     sendExtendedEvent(
       ExtendedDataEvent(
-        auditSource = auditingConfig.auditSource,
-        auditType   = auditType,
-        eventId     = UUID.randomUUID().toString,
-        tags        = hc.toAuditTags(),
-        detail      = detail
+        auditProvider = auditingConfig.auditProvider,
+        auditSource   = auditingConfig.auditSource,
+        auditType     = auditType,
+        eventId       = UUID.randomUUID().toString,
+        tags          = hc.toAuditTags(),
+        detail        = detail
       )
     )
 

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
@@ -29,7 +29,8 @@ case class DataEvent(
   detail       : Map[String, String] = Map.empty,
   generatedAt  : Instant             = Instant.now(),
   truncationLog: TruncationLog       = TruncationLog.Empty,
-  redactionLog : RedactionLog        = RedactionLog.Empty
+  redactionLog : RedactionLog        = RedactionLog.Empty,
+  auditProvider: Option[String]      = None
 )
 
 case class ExtendedDataEvent(
@@ -40,7 +41,8 @@ case class ExtendedDataEvent(
   detail       : JsValue             = JsString(""),
   generatedAt  : Instant             = Instant.now(),
   truncationLog: TruncationLog       = TruncationLog.Empty,
-  redactionLog : RedactionLog        = RedactionLog.Empty
+  redactionLog : RedactionLog        = RedactionLog.Empty,
+  auditProvider: Option[String]      = None
 )
 
 case class DataCall(
@@ -52,11 +54,12 @@ case class DataCall(
 case class MergedDataEvent(
   auditSource  : String,
   auditType    : String,
-  eventId      : String        = UUID.randomUUID().toString,
+  eventId      : String         = UUID.randomUUID().toString,
   request      : DataCall,
   response     : DataCall,
-  truncationLog: TruncationLog = TruncationLog.Empty,
-  redactionLog : RedactionLog  = RedactionLog.Empty
+  truncationLog: TruncationLog  = TruncationLog.Empty,
+  redactionLog : RedactionLog   = RedactionLog.Empty,
+  auditProvider: Option[String] = None
 )
 
 sealed trait TruncationLog {

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfigSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfigSpec.scala
@@ -30,14 +30,16 @@ class AuditingConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         "auditing.enabled"               -> "true",
         "auditing.consumer.baseUri.host" -> "localhost",
         "auditing.consumer.baseUri.port" -> "8100",
-        "auditing.auditSentHeaders"      -> "false"
+        "auditing.auditSentHeaders"      -> "false",
+        "auditing.auditProvider"         -> "audit-provider"
       )
 
       AuditingConfig.fromConfig(config) shouldBe AuditingConfig(
         consumer         = Some(Consumer(BaseUri("localhost", 8100, "http"))),
         enabled          = true,
         auditSource      = "app-name",
-        auditSentHeaders = false
+        auditSentHeaders = false,
+        auditProvider    = Some("audit-provider")
       )
     }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")


### PR DESCRIPTION
## What?

Adds `auditProvider` as an optional attribute as per the CIP [Audit Event Specification](https://confluence.tools.tax.service.gov.uk/display/CIP/Auditing+Event+Specification).
Default to `None`.
Allow setting of `auditProvider` in configuration and explicitly via the `send` methods.

## Why?

Needed to support One Login auditing and eventually to enable MDTP microservices to set this attribute.