### PR TITLE
Add compile-time check for audit event schemas

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,5 @@
+version = 3.10.7
+runner.dialect = scala3
+
+align.preset = more    // For pretty alignment.
+maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scala3    = "3.3.6"
 ThisBuild / majorVersion     := 9
 ThisBuild / scalaVersion     := scala3
 ThisBuild / isPublicArtefact := true
-ThisBuild / scalacOptions    ++= Seq("-feature")
+ThisBuild / scalacOptions ++= Seq("-feature")
 
 lazy val library = (project in file("."))
   .settings(publish / skip := true)
@@ -19,9 +19,9 @@ lazy val playAuditingPlay30 = Project("play-auditing-play-30", file("play-auditi
     crossScalaVersions := Seq(scala2_13, scala3),
     libraryDependencies ++= LibDependencies.common ++ LibDependencies.play30,
     // without this, DatastreamHandlerWireSpec sometimes fails with `play.shaded.ahc.io.netty.handler.codec.EncoderException: java.lang.OutOfMemoryError: Direct buffer memory`
-    Test / fork := true,
+    Test / fork := true
   )
   .settings( // https://github.com/sbt/sbt-buildinfo
     buildInfoKeys    := Seq[BuildInfoKey](version),
     buildInfoPackage := "uk.gov.hmrc.audit"
-   )
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val scala2_13 = "2.13.16"
 val scala3    = "3.3.6"
 
 ThisBuild / majorVersion     := 9
-ThisBuild / scalaVersion     := scala2_13
+ThisBuild / scalaVersion     := scala3
 ThisBuild / isPublicArtefact := true
 ThisBuild / scalacOptions    ++= Seq("-feature")
 
@@ -19,7 +19,7 @@ lazy val playAuditingPlay30 = Project("play-auditing-play-30", file("play-auditi
     crossScalaVersions := Seq(scala2_13, scala3),
     libraryDependencies ++= LibDependencies.common ++ LibDependencies.play30,
     // without this, DatastreamHandlerWireSpec sometimes fails with `play.shaded.ahc.io.netty.handler.codec.EncoderException: java.lang.OutOfMemoryError: Direct buffer memory`
-    Test / fork := true
+    Test / fork := true,
   )
   .settings( // https://github.com/sbt/sbt-buildinfo
     buildInfoKeys    := Seq[BuildInfoKey](version),

--- a/play-auditing-play-30/src/main/java/uk/gov/hmrc/audit/http/validation/CipAuditEventSchema.java
+++ b/play-auditing-play-30/src/main/java/uk/gov/hmrc/audit/http/validation/CipAuditEventSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.audit
+package uk.gov.hmrc.audit.http.validation;
 
-import org.scalatestplus.mockito.MockitoSugar.mock
-import uk.gov.hmrc.play.audit.http.connector.{DatastreamMetrics, Counter}
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-trait DatastreamMetricsMock {
-
-  def mockDatastreamMetrics(metricsKey: Option[String]): DatastreamMetrics =
-    DatastreamMetrics(
-      mock[Counter],
-      mock[Counter],
-      mock[Counter],
-      metricsKey
-    )
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CipAuditEventSchema {
+    public String schemaFile() default "";
 }

--- a/play-auditing-play-30/src/main/java/uk/gov/hmrc/audit/http/validation/CipAuditEventUnvalidated.java
+++ b/play-auditing-play-30/src/main/java/uk/gov/hmrc/audit/http/validation/CipAuditEventUnvalidated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.audit
+package uk.gov.hmrc.audit.http.validation;
 
-import org.scalatestplus.mockito.MockitoSugar.mock
-import uk.gov.hmrc.play.audit.http.connector.{DatastreamMetrics, Counter}
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-trait DatastreamMetricsMock {
-
-  def mockDatastreamMetrics(metricsKey: Option[String]): DatastreamMetrics =
-    DatastreamMetrics(
-      mock[Counter],
-      mock[Counter],
-      mock[Counter],
-      metricsKey
-    )
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CipAuditEventUnvalidated {
 }

--- a/play-auditing-play-30/src/main/scala-2.13/AuditEventSchema.scala
+++ b/play-auditing-play-30/src/main/scala-2.13/AuditEventSchema.scala
@@ -16,13 +16,17 @@
 
 package uk.gov.hmrc.play.audit.http.validation
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
+import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
-object AuditMacros {
+object AuditEventSchema {
 
-  def nonvalidatedFormat[T]: AuditFormat[T] = macro nonvalidatedFormatImpl[T]
+
+  private val unvalidatedSchemaAnnotation               = classOf[CipAuditEventUnvalidated].getCanonicalName()
+
+  def unvalidatedFormat[T]: AuditFormat[T] = macro nonvalidatedFormatImpl[T]
 
   def nonvalidatedFormatImpl[T: c.WeakTypeTag](c: Context): c.Expr[AuditFormat[T]] = {
     import c.universe._

--- a/play-auditing-play-30/src/main/scala-2.13/AuditMacros.scala
+++ b/play-auditing-play-30/src/main/scala-2.13/AuditMacros.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+package uk.gov.hmrc.play.audit.http.validation
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 
 import scala.language.experimental.macros
@@ -30,11 +31,11 @@ object AuditMacros {
     val symbol = tpe.typeSymbol
 
     val hasAnnotation = symbol.annotations.exists { ann =>
-      ann.tree.tpe.toString.contains("nonValidatedAnnotation")
+      ann.tree.tpe.toString.contains("CipAuditEventUnvalidated")
     }
 
     if (!hasAnnotation) {
-      c.abort(c.enclosingPosition, s"${symbol.name} must be annotated with @nonValidatedAnnotation")
+      c.abort(c.enclosingPosition, s"${symbol.name} must be annotated with @@CipAuditEventUnvalidated")
     }
 
     val formatTree = q"play.api.libs.json.Json.format[$tpe]"

--- a/play-auditing-play-30/src/main/scala-2.13/AuditMacros.scala
+++ b/play-auditing-play-30/src/main/scala-2.13/AuditMacros.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import uk.gov.hmrc.play.audit.http.validation.AuditFormat
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object AuditMacros {
+
+  def nonvalidatedFormat[T]: AuditFormat[T] = macro nonvalidatedFormatImpl[T]
+
+  def nonvalidatedFormatImpl[T: c.WeakTypeTag](c: Context): c.Expr[AuditFormat[T]] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[T]
+    val symbol = tpe.typeSymbol
+
+    val hasAnnotation = symbol.annotations.exists { ann =>
+      ann.tree.tpe.toString.contains("nonValidatedAnnotation")
+    }
+
+    if (!hasAnnotation) {
+      c.abort(c.enclosingPosition, s"${symbol.name} must be annotated with @nonValidatedAnnotation")
+    }
+
+    val formatTree = q"play.api.libs.json.Json.format[$tpe]"
+
+    c.Expr[AuditFormat[T]](q"new AuditFormat[$tpe]($formatTree)")
+  }
+}

--- a/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/AuditEventSchema.scala
+++ b/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/AuditEventSchema.scala
@@ -26,18 +26,20 @@ import java.time.LocalDate
 import scala.jdk.CollectionConverters.*
 import scala.quoted.*
 import scala.util.Random
+import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
 
-object JsonValidatorMacro:
+object AuditEventSchema:
 
-  private val cipSchemaAnnotation                  = "uk.gov.hmrc.audit.http.validation.CipAuditEventSchema"
-  private val nonValidatedAnnotation               = "uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated"
-  inline def nonvalidatedFormat[T]: AuditFormat[T] = ${ unvalidatedFormatImpl[T] }
+  private val cipSchemaAnnotation                  = classOf[CipAuditEventSchema].getCanonicalName() 
+  private val unvalidatedSchemaAnnotation               = classOf[CipAuditEventUnvalidated].getCanonicalName()
+  inline def unvalidatedFormat[T]: AuditFormat[T] = ${ unvalidatedFormatImpl[T] }
 
   def unvalidatedFormatImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
     import quotes.reflect.*
     val typeSymbol = TypeRepr.of[T].typeSymbol
-    if !typeSymbol.annotations.exists(_.tpe.show == nonValidatedAnnotation) then
-      report.errorAndAbort(s"${typeSymbol.name} must be annotated with @$nonValidatedAnnotation")
+    if !typeSymbol.annotations.exists(_.tpe.show == unvalidatedSchemaAnnotation) then
+      report.errorAndAbort(s"${typeSymbol.name} must be annotated with @$unvalidatedSchemaAnnotation")
 
     val format = JsMacroImpl.format[T]
 
@@ -45,9 +47,9 @@ object JsonValidatorMacro:
       new AuditFormat[T]($format)
     }
 
-  inline def generateValidatedJson[T]: AuditFormat[T] = ${ generateImpl[T] }
+  inline def format[T]: AuditFormat[T] = ${ generateFormatImpl[T] }
 
-  def generateImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
+  def generateFormatImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
     import quotes.reflect.*
 
     def buildJson(tpe: TypeRepr): JsValue =

--- a/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacro.scala
+++ b/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacro.scala
@@ -29,24 +29,22 @@ import scala.util.Random
 
 object JsonValidatorMacro:
 
-  private val cipSchemaAnnotation                          = "uk.gov.hmrc.audit.http.validation.CipAuditEventSchema"
-  private val nonValidatedAnnotation = "uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated"
+  private val cipSchemaAnnotation                  = "uk.gov.hmrc.audit.http.validation.CipAuditEventSchema"
+  private val nonValidatedAnnotation               = "uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated"
   inline def nonvalidatedFormat[T]: AuditFormat[T] = ${ unvalidatedFormatImpl[T] }
-  
+
   def unvalidatedFormatImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
     import quotes.reflect.*
     val typeSymbol = TypeRepr.of[T].typeSymbol
     if !typeSymbol.annotations.exists(_.tpe.show == nonValidatedAnnotation) then
       report.errorAndAbort(s"${typeSymbol.name} must be annotated with @$nonValidatedAnnotation")
-    
-    
+
     val format = JsMacroImpl.format[T]
-    
+
     '{
       new AuditFormat[T]($format)
     }
-  
-  
+
   inline def generateValidatedJson[T]: AuditFormat[T] = ${ generateImpl[T] }
 
   def generateImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
@@ -101,7 +99,6 @@ object JsonValidatorMacro:
     '{
       new AuditFormat[T]($format)
     }
-
 
   private def loadSchema[T: Type](using Quotes): URI = {
     import quotes.reflect.*

--- a/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacro.scala
+++ b/play-auditing-play-30/src/main/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacro.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.validation
+
+import com.networknt.schema.regex.JoniRegularExpressionFactory
+import com.networknt.schema.{SchemaLocation, SchemaRegistry}
+import play.api.libs.json.*
+import tools.jackson.databind.{JsonNode, ObjectMapper}
+
+import java.net.URI
+import java.time.LocalDate
+import scala.jdk.CollectionConverters.*
+import scala.quoted.*
+import scala.util.Random
+
+object JsonValidatorMacro:
+
+  private val cipSchemaAnnotation                          = "uk.gov.hmrc.audit.http.validation.CipAuditEventSchema"
+  private val nonValidatedAnnotation = "uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated"
+  inline def nonvalidatedFormat[T]: AuditFormat[T] = ${ unvalidatedFormatImpl[T] }
+  
+  def unvalidatedFormatImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
+    import quotes.reflect.*
+    val typeSymbol = TypeRepr.of[T].typeSymbol
+    if !typeSymbol.annotations.exists(_.tpe.show == nonValidatedAnnotation) then
+      report.errorAndAbort(s"${typeSymbol.name} must be annotated with @$nonValidatedAnnotation")
+    
+    
+    val format = JsMacroImpl.format[T]
+    
+    '{
+      new AuditFormat[T]($format)
+    }
+  
+  
+  inline def generateValidatedJson[T]: AuditFormat[T] = ${ generateImpl[T] }
+
+  def generateImpl[T: Type](using Quotes): Expr[AuditFormat[T]] =
+    import quotes.reflect.*
+
+    def buildJson(tpe: TypeRepr): JsValue =
+      val sym = tpe.typeSymbol
+
+      tpe.asType match
+        case '[String] =>
+          JsString(Random.alphanumeric.take(8).mkString)
+        case '[Int] =>
+          JsNumber(Random.nextInt(100))
+        case '[Boolean] =>
+          JsBoolean(Random.nextBoolean())
+        case '[Double] =>
+          JsNumber(Random.nextDouble())
+        case '[LocalDate] =>
+          JsString(LocalDate.now.toString)
+        case '[Option[t]] =>
+          buildJson(TypeRepr.of[t])
+        case '[List[t]] =>
+          JsArray(List(buildJson(TypeRepr.of[t])))
+        case '[Set[t]] =>
+          JsArray(Seq(buildJson(TypeRepr.of[t])))
+        case _ if tpe.typeSymbol.flags.is(Flags.Enum) =>
+          val sym   = tpe.typeSymbol
+          val cases = sym.children
+          if cases.isEmpty then report.errorAndAbort(s"Enum ${sym.name} has no cases.")
+
+          val randomCaseSymbol = cases(Random.nextInt(cases.size))
+
+          if !randomCaseSymbol.isClassDef then JsString(randomCaseSymbol.name)
+          else buildJson(tpe.memberType(randomCaseSymbol))
+        case t if sym.isClassDef && sym.flags.is(Flags.Case) =>
+          val fields = sym.caseFields
+          val body   = fields
+            .map { field =>
+              val name     = field.name
+              val fieldTpe = tpe.memberType(field)
+              name -> buildJson(fieldTpe)
+            }
+          JsObject(body)
+        case _ => report.errorAndAbort(s"Unsupported type: ${tpe.show}")
+
+    val generatedJson = buildJson(TypeRepr.of[T])
+
+    val schema = loadSchema[T]
+
+    if !isValidJson(generatedJson.toString, schema) then report.errorAndAbort(s"AuditEvent does not match CIP Schema")
+    val format: Expr[OFormat[T]] = JsMacroImpl.format[T]
+    '{
+      new AuditFormat[T]($format)
+    }
+
+
+  private def loadSchema[T: Type](using Quotes): URI = {
+    import quotes.reflect.*
+    val typeSymbol = TypeRepr.of[T].typeSymbol
+    val annot      = typeSymbol.annotations.find(_.tpe.show == cipSchemaAnnotation).getOrElse {
+      report.errorAndAbort(s"${typeSymbol.name} must be annotated with @$cipSchemaAnnotation")
+    }
+
+    val schemaFile: String = annot match {
+      case Apply(Select(New(_), _), List(NamedArg("schemaFile", Literal(c)))) => c.value.toString
+      case _ => report.errorAndAbort("Could not read schemaFile path from annotation.")
+    }
+    URI.create(s"resource:$schemaFile")
+  }
+
+  private def isValidJson(json: String, schemaUri: URI)(using Quotes): Boolean = {
+    import com.networknt.schema.SchemaRegistryConfig
+    import quotes.reflect.*
+    val schemaRegistryConfig: SchemaRegistryConfig = SchemaRegistryConfig
+      .builder()
+      .regularExpressionFactory(JoniRegularExpressionFactory.getInstance())
+      .build()
+
+    val schemaLocation     = SchemaLocation.of(schemaUri.toString)
+    val schemaRegistry     = SchemaRegistry.builder().schemaRegistryConfig(schemaRegistryConfig).build()
+    val schema             = schemaRegistry.getSchema(schemaLocation)
+    val objMapper          = new ObjectMapper()
+    val jsonnode: JsonNode = objMapper.readTree(json)
+    val errors             = schema.validate(jsonnode).asScala
+
+    errors.foreach(f => {
+      report.info(s"Failed CIP validation: ${f.toString}")
+    })
+    errors.isEmpty
+  }

--- a/play-auditing-play-30/src/main/scala/WSClient.scala
+++ b/play-auditing-play-30/src/main/scala/WSClient.scala
@@ -28,20 +28,21 @@ package object audit {
   // these are for internal use only, but can't be package private since clients are in uk.gov.hmrc.audit and uk.gov.hmrc.play.audit...
   object WSClient {
     def apply(
-      connectTimeout: Duration,
-      requestTimeout: Duration,
-      userAgent     : String
+        connectTimeout: Duration,
+        requestTimeout: Duration,
+        userAgent: String
     )(implicit
-      materializer: Materializer
+        materializer: Materializer
     ): WSClient =
       StandaloneAhcWSClient(
-        config = AhcWSClientConfigFactory.forConfig()
+        config = AhcWSClientConfigFactory
+          .forConfig()
           .copy(
             wsClientConfig = WSClientConfig()
               .copy(
                 connectionTimeout = connectTimeout,
-                requestTimeout    = requestTimeout,
-                userAgent         = Some(userAgent),
+                requestTimeout = requestTimeout,
+                userAgent = Some(userAgent)
               )
           )
       )

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/AuditHandler.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/AuditHandler.scala
@@ -22,5 +22,7 @@ import uk.gov.hmrc.audit.HandlerResult
 import scala.concurrent.{ExecutionContext, Future}
 
 trait AuditHandler {
-  def sendEvent(event: JsValue)(implicit ec: ExecutionContext): Future[HandlerResult]
+  def sendEvent(event: JsValue)(implicit
+      ec: ExecutionContext
+  ): Future[HandlerResult]
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/DatastreamHandler.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/DatastreamHandler.scala
@@ -26,20 +26,23 @@ import uk.gov.hmrc.play.audit.http.connector.DatastreamMetrics
 import scala.concurrent.{ExecutionContext, Future}
 
 class DatastreamHandler(
-  scheme  : String,
-  host    : String,
-  port    : Integer,
-  path    : String,
-  wsClient: WSClient,
-  metrics: DatastreamMetrics,
+    scheme: String,
+    host: String,
+    port: Integer,
+    path: String,
+    wsClient: WSClient,
+    metrics: DatastreamMetrics
 ) extends HttpHandler(
-  endpointUrl = new URL(s"$scheme://$host:$port$path"),
-  wsClient    = wsClient
-) with AuditHandler {
+      endpointUrl = new URL(s"$scheme://$host:$port$path"),
+      wsClient = wsClient
+    )
+    with AuditHandler {
 
-  private[handler] val logger : Logger = LoggerFactory.getLogger(getClass)
+  private[handler] val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  override def sendEvent(event: JsValue)(implicit ec: ExecutionContext): Future[HandlerResult] =
+  override def sendEvent(
+      event: JsValue
+  )(implicit ec: ExecutionContext): Future[HandlerResult] =
     sendHttpRequest(event).flatMap {
       case HttpResult.Response(status) =>
         Future.successful(status match {
@@ -48,23 +51,28 @@ class DatastreamHandler(
             Success
           case 400 | 413 =>
             metrics.rejectCounter.inc()
-            logger.warn(s"AUDIT_REJECTED: received response with $status status code")
+            logger.warn(
+              s"AUDIT_REJECTED: received response with $status status code"
+            )
             Rejected
-          case _   =>
+          case _ =>
             metrics.failureCounter.inc()
-            logger.warn(s"AUDIT_FAILURE: received response with $status status code")
+            logger.warn(
+              s"AUDIT_FAILURE: received response with $status status code"
+            )
             Failure
         })
       case HttpResult.Malformed =>
         metrics.failureCounter.inc()
         logger.warn("AUDIT_FAILURE: received malformed response")
-          Future.successful(Failure)
+        Future.successful(Failure)
       case HttpResult.Failure(msg, exceptionOption) =>
         metrics.failureCounter.inc()
 
         exceptionOption match {
           case None     => logger.warn(s"AUDIT_FAILURE: failed with error '$msg'")
-          case Some(ex) => logger.warn(s"AUDIT_FAILURE: failed with error '$msg'", ex)
+          case Some(ex) =>
+            logger.warn(s"AUDIT_FAILURE: failed with error '$msg'", ex)
         }
         Future.successful(Failure)
     }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/HttpHandler.scala
@@ -25,29 +25,34 @@ import uk.gov.hmrc.mdc.Mdc
 import java.net.URL
 import scala.concurrent.{ExecutionContext, Future}
 
-
 sealed trait HttpResult
 object HttpResult {
   case class Response(statusCode: Int) extends HttpResult
-  case object Malformed extends HttpResult
-  case class Failure(msg: String, nested: Option[Throwable] = None) extends Exception(msg, nested.orNull) with HttpResult
+  case object Malformed                extends HttpResult
+  case class Failure(msg: String, nested: Option[Throwable] = None)
+      extends Exception(msg, nested.orNull)
+      with HttpResult
 }
 
 class HttpHandler(
-  endpointUrl: URL,
-  wsClient   : WSClient
+    endpointUrl: URL,
+    wsClient: WSClient
 ) {
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
   val HTTP_STATUS_CONTINUE = 100
 
-  def sendHttpRequest(event: JsValue)(implicit ec: ExecutionContext): Future[HttpResult] =
+  def sendHttpRequest(
+      event: JsValue
+  )(implicit ec: ExecutionContext): Future[HttpResult] =
     try {
       logger.debug(s"Sending audit request to URL ${endpointUrl.toString}")
-      Mdc.preservingMdc(
-        wsClient.url(endpointUrl.toString)
-          .post(event)
-      )
+      Mdc
+        .preservingMdc(
+          wsClient
+            .url(endpointUrl.toString)
+            .post(event)
+        )
         .map { response =>
           val httpStatusCode = response.status
           logger.debug(s"Got status code : $httpStatusCode")
@@ -58,15 +63,25 @@ class HttpHandler(
             logger.debug(s"Got status code $httpStatusCode from HTTP server.")
             HttpResult.Response(httpStatusCode)
           } else {
-            logger.warn(s"Malformed response (status $httpStatusCode) returned from server")
+            logger.warn(
+              s"Malformed response (status $httpStatusCode) returned from server"
+            )
             HttpResult.Malformed
           }
-        }.recover {
-          case e: Throwable =>
-            HttpResult.Failure("Error opening connection or sending request (async)", Some(e))
+        }
+        .recover { case e: Throwable =>
+          HttpResult.Failure(
+            "Error opening connection or sending request (async)",
+            Some(e)
+          )
         }
     } catch {
       case e: Throwable =>
-        Future.successful(HttpResult.Failure("Error opening connection or sending request (sync)", Some(e)))
+        Future.successful(
+          HttpResult.Failure(
+            "Error opening connection or sending request (sync)",
+            Some(e)
+          )
+        )
     }
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/LoggingHandler.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/handler/LoggingHandler.scala
@@ -29,7 +29,9 @@ class LoggingHandler(logger: Logger) extends AuditHandler {
   def makeFailureMessage(event: JsValue): String =
     s"$ErrorKey : audit item : ${event.toString}"
 
-  override def sendEvent(event: JsValue)(implicit ec: ExecutionContext): Future[HandlerResult] = {
+  override def sendEvent(
+      event: JsValue
+  )(implicit ec: ExecutionContext): Future[HandlerResult] = {
     val message = makeFailureMessage(event)
     logger.warn(message)
     Future.successful(HandlerResult.Success)

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiser.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiser.scala
@@ -38,16 +38,17 @@ class AuditSerialiser extends AuditSerialiserLike {
     )
 
   private implicit val truncationLogWriterEntry: Writes[TruncationLog.Entry] =
-    Writes[TruncationLog.Entry] {
-      case TruncationLog.Entry(truncatedFields, timestamp) =>
-        Json.obj(
-          "truncationLog" -> Json.arr(Json.obj(
-              "truncatedFields" -> truncatedFields,
-              "timestamp"       -> timestamp,
-              "code"            -> "play-auditing",
-              "version"         -> BuildInfo.version
-            ))
+    Writes[TruncationLog.Entry] { case TruncationLog.Entry(truncatedFields, timestamp) =>
+      Json.obj(
+        "truncationLog" -> Json.arr(
+          Json.obj(
+            "truncatedFields" -> truncatedFields,
+            "timestamp"       -> timestamp,
+            "code"            -> "play-auditing",
+            "version"         -> BuildInfo.version
+          )
         )
+      )
     }
 
   private implicit val redactionLogWriter: Writes[RedactionLog] =
@@ -57,56 +58,94 @@ class AuditSerialiser extends AuditSerialiserLike {
       case RedactionLog.Entry(redactedFields, timestamp) =>
         Json.obj(
           "containsRedactions" -> true,
-          "redactionLog"       -> Json.arr(Json.obj(
-            "redactedFields" -> redactedFields,
-            "timestamp"      -> timestamp,
-            "code"           -> "play-auditing",
-            "version"        -> BuildInfo.version
-          ))
-      )
+          "redactionLog"       -> Json.arr(
+            Json.obj(
+              "redactedFields" -> redactedFields,
+              "timestamp"      -> timestamp,
+              "code"           -> "play-auditing",
+              "version"        -> BuildInfo.version
+            )
+          )
+        )
     }
 
   private implicit val dataEventWriter: Writes[DataEvent] =
-    ( (__ \ "auditProvider"              ).writeNullable[String]
-    ~ (__ \ "auditSource"                ).write[String]
-    ~ (__ \ "auditType"                  ).write[String]
-    ~ (__ \ "eventId"                    ).write[String]
-    ~ (__ \ "tags"                       ).write[Map[String, String]]
-    ~ (__ \ "detail"                     ).write[Map[String, String]]
-    ~ (__ \ "generatedAt"                ).write[Instant]
-    ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
-    ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
+    ((__ \ "auditProvider").writeNullable[String]
+      ~ (__ \ "auditSource").write[String]
+      ~ (__ \ "auditType").write[String]
+      ~ (__ \ "eventId").write[String]
+      ~ (__ \ "tags").write[Map[String, String]]
+      ~ (__ \ "detail").write[Map[String, String]]
+      ~ (__ \ "generatedAt").write[Instant]
+      ~ (__ \ "dataPipeline" \ "truncation")
+        .writeNullable[TruncationLog.Entry]
+        .contramap[TruncationLog](_.asEntry)
+      ~ (__ \ "dataPipeline" \ "redaction").write[RedactionLog])(de =>
+      (
+        de.auditProvider,
+        de.auditSource,
+        de.auditType,
+        de.eventId,
+        de.tags,
+        de.detail,
+        de.generatedAt,
+        de.truncationLog,
+        de.redactionLog
+      )
+    )
 
   private implicit val extendedDataEventWriter: Writes[ExtendedDataEvent] =
-    ( (__ \ "auditProvider"              ).writeNullable[String]
-    ~ (__ \ "auditSource"                ).write[String]
-    ~ (__ \ "auditType"                  ).write[String]
-    ~ (__ \ "eventId"                    ).write[String]
-    ~ (__ \ "tags"                       ).write[Map[String, String]]
-    ~ (__ \ "detail"                     ).write[JsValue]
-    ~ (__ \ "generatedAt"                ).write[Instant]
-    ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
-    ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.tags, de.detail, de.generatedAt, de.truncationLog, de.redactionLog))
+    ((__ \ "auditProvider").writeNullable[String]
+      ~ (__ \ "auditSource").write[String]
+      ~ (__ \ "auditType").write[String]
+      ~ (__ \ "eventId").write[String]
+      ~ (__ \ "tags").write[Map[String, String]]
+      ~ (__ \ "detail").write[JsValue]
+      ~ (__ \ "generatedAt").write[Instant]
+      ~ (__ \ "dataPipeline" \ "truncation")
+        .writeNullable[TruncationLog.Entry]
+        .contramap[TruncationLog](_.asEntry)
+      ~ (__ \ "dataPipeline" \ "redaction").write[RedactionLog])(de =>
+      (
+        de.auditProvider,
+        de.auditSource,
+        de.auditType,
+        de.eventId,
+        de.tags,
+        de.detail,
+        de.generatedAt,
+        de.truncationLog,
+        de.redactionLog
+      )
+    )
 
   private implicit val dataCallWriter: Writes[DataCall] =
-    ( (__ \ "tags"       ).write[Map[String, String]]
-    ~ (__ \ "detail"     ).write[Map[String, String]]
-    ~ (__ \ "generatedAt").write[Instant]
-    )(dc => (dc.tags, dc.detail, dc.generatedAt))
+    ((__ \ "tags").write[Map[String, String]]
+      ~ (__ \ "detail").write[Map[String, String]]
+      ~ (__ \ "generatedAt").write[Instant])(dc => (dc.tags, dc.detail, dc.generatedAt))
 
-  private implicit val mergedDataEventWriter  : Writes[MergedDataEvent]   =
-    ( (__ \ "auditProvider"              ).writeNullable[String]
-    ~ (__ \ "auditSource"                ).write[String]
-    ~ (__ \ "auditType"                  ).write[String]
-    ~ (__ \ "eventId"                    ).write[String]
-    ~ (__ \ "request"                    ).write[DataCall]
-    ~ (__ \ "response"                   ).write[DataCall]
-    ~ (__ \ "dataPipeline" \ "truncation").writeNullable[TruncationLog.Entry].contramap[TruncationLog](_.asEntry)
-    ~ (__ \ "dataPipeline" \ "redaction" ).write[RedactionLog]
-    )(de => (de.auditProvider, de.auditSource, de.auditType, de.eventId, de.request, de.response, de.truncationLog, de.redactionLog))
-
+  private implicit val mergedDataEventWriter: Writes[MergedDataEvent] =
+    ((__ \ "auditProvider").writeNullable[String]
+      ~ (__ \ "auditSource").write[String]
+      ~ (__ \ "auditType").write[String]
+      ~ (__ \ "eventId").write[String]
+      ~ (__ \ "request").write[DataCall]
+      ~ (__ \ "response").write[DataCall]
+      ~ (__ \ "dataPipeline" \ "truncation")
+        .writeNullable[TruncationLog.Entry]
+        .contramap[TruncationLog](_.asEntry)
+      ~ (__ \ "dataPipeline" \ "redaction").write[RedactionLog])(de =>
+      (
+        de.auditProvider,
+        de.auditSource,
+        de.auditType,
+        de.eventId,
+        de.request,
+        de.response,
+        de.truncationLog,
+        de.redactionLog
+      )
+    )
 
   override def serialise(event: DataEvent): JsObject =
     Json.toJson(event).as[JsObject]

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/AuditExtensions.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/AuditExtensions.scala
@@ -28,18 +28,26 @@ object AuditExtensions {
       carrier.names.xSessionId -> carrier.sessionId.map(_.value).getOrElse("-"),
       "clientIP"               -> carrier.trueClientIp.getOrElse("-"),
       "clientPort"             -> carrier.trueClientPort.getOrElse("-"),
-      "Akamai-Reputation"      -> carrier.akamaiReputation.getOrElse(AkamaiReputation("-")).value,
-      carrier.names.deviceID   -> carrier.deviceID.getOrElse("-"),
-      //path is not a header but http-verbs-play-25 puts it in HeaderCarrier.otherHeaders so that play-auditing can
-      //get the request path without depending on play and without modifying http-core
-      //Modifying http-core is hard right now because it depends on play 2.6
-      "path"                   -> carrier.otherHeaders.collect { case ("path", value) => value }.headOption.getOrElse("-")
+      "Akamai-Reputation"      -> carrier.akamaiReputation
+        .getOrElse(AkamaiReputation("-"))
+        .value,
+      carrier.names.deviceID -> carrier.deviceID.getOrElse("-"),
+      // path is not a header but http-verbs-play-25 puts it in HeaderCarrier.otherHeaders so that play-auditing can
+      // get the request path without depending on play and without modifying http-core
+      // Modifying http-core is hard right now because it depends on play 2.6
+      "path" -> carrier.otherHeaders
+        .collect { case ("path", value) => value }
+        .headOption
+        .getOrElse("-")
     )
 
-    def toAuditTags(transactionName: String, path: String): Map[String, String] = {
+    def toAuditTags(
+        transactionName: String,
+        path: String
+    ): Map[String, String] = {
       auditTags ++ Map[String, String](
         TransactionName -> transactionName,
-        Path -> path
+        Path            -> path
       )
     }
 

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/AuditModule.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/AuditModule.scala
@@ -24,11 +24,10 @@ import _root_.uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditConnecto
 
 import javax.inject.{Inject, Singleton}
 
-
 class AuditModule extends Module {
   override def bindings(
-    environment  : Environment,
-    configuration: Configuration
+      environment: Environment,
+      configuration: Configuration
   ): Seq[Binding[_]] = Seq(
     bind[AuditChannel].to[DefaultAuditChannel],
     bind[AuditConnector].to[DefaultAuditConnector],
@@ -37,17 +36,17 @@ class AuditModule extends Module {
 }
 
 @Singleton
-class DefaultAuditChannel @Inject()(
-  val auditingConfig   : AuditingConfig,
-  val materializer     : Materializer,
-  val lifecycle        : ApplicationLifecycle,
-  val datastreamMetrics: DatastreamMetrics
+class DefaultAuditChannel @Inject() (
+    val auditingConfig: AuditingConfig,
+    val materializer: Materializer,
+    val lifecycle: ApplicationLifecycle,
+    val datastreamMetrics: DatastreamMetrics
 ) extends AuditChannel
 
 @Singleton
-class DefaultAuditConnector @Inject()(
-  val auditingConfig   : AuditingConfig,
-  val auditChannel     : AuditChannel,
-  val lifecycle        : ApplicationLifecycle,
-  val datastreamMetrics: DatastreamMetrics
+class DefaultAuditConnector @Inject() (
+    val auditingConfig: AuditingConfig,
+    val auditChannel: AuditChannel,
+    val lifecycle: ApplicationLifecycle,
+    val datastreamMetrics: DatastreamMetrics
 ) extends AuditConnector

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/HttpAuditing.scala
@@ -62,17 +62,18 @@ trait HttpAuditing {
 
   object AuditingHook extends HttpHook {
     override def apply(
-      verb     : String,
-      url      : URL,
-      request  : RequestData,
-      responseF: Future[ResponseData]
+        verb: String,
+        url: URL,
+        request: RequestData,
+        responseF: Future[ResponseData]
     )(implicit
-      hc: HeaderCarrier,
-      ec: ExecutionContext
+        hc: HeaderCarrier,
+        ec: ExecutionContext
     ): Unit =
       // short-circuit the payload creation
       if (auditConnector.isEnabled) {
-        val httpRequest = HttpRequest(verb, url.toString, request.headers, request.body, now())
+        val httpRequest =
+          HttpRequest(verb, url.toString, request.headers, request.body, now())
         responseF
           .map(Right.apply)
           .recover { case e: Throwable => Left(e.getMessage) }
@@ -80,22 +81,28 @@ trait HttpAuditing {
       }
   }
 
-  private[http] def audit(request: HttpRequest, responseToAudit: Either[String, ResponseData])(implicit hc: HeaderCarrier, ex: ExecutionContext): Unit =
+  private[http] def audit(
+      request: HttpRequest,
+      responseToAudit: Either[String, ResponseData]
+  )(implicit hc: HeaderCarrier, ex: ExecutionContext): Unit =
     if (isAuditable(request.url))
-      auditConnector.sendMergedEvent(
-        buildDataEvent(
-          request  = request,
-          response = responseToAudit
+      auditConnector
+        .sendMergedEvent(
+          buildDataEvent(
+            request = request,
+            response = responseToAudit
+          )
         )
-      ).onComplete {
-        case Success(AuditResult.Success | AuditResult.Disabled)  =>
-        case Success(AuditResult.Failure(msg, _))                 => // already logged
-        case Failure(ex)                                          => logger.error(s"Failed to audit http event: ${ex.getMessage}", ex)
-      }
+        .onComplete {
+          case Success(AuditResult.Success | AuditResult.Disabled) =>
+          case Success(AuditResult.Failure(msg, _))                => // already logged
+          case Failure(ex)                                         =>
+            logger.error(s"Failed to audit http event: ${ex.getMessage}", ex)
+        }
 
   private def buildDataEvent(
-    request            : HttpRequest,
-    response           : Either[String, ResponseData]
+      request: HttpRequest,
+      response: Either[String, ResponseData]
   )(implicit hc: HeaderCarrier) = {
     import AuditExtensions._
     val requestDetailsData =
@@ -107,52 +114,66 @@ trait HttpAuditing {
           Data.pure(Map(EventKeys.FailedRequestMessage -> errorMessage))
         case Right(response) =>
           for {
-            responseBody <- response.body
+            responseBody       <- response.body
             maskedResponseBody <- maskString(responseBody)
-          } yield
-            Map(
-              EventKeys.StatusCode      -> response.status.toString,
-              EventKeys.ResponseMessage -> maskedResponseBody
-            )
+          } yield Map(
+            EventKeys.StatusCode      -> response.status.toString,
+            EventKeys.ResponseMessage -> maskedResponseBody
+          )
       }
 
     val truncatedFields =
-      (if (requestDetailsData.isTruncated) List(s"request.detail.${EventKeys.RequestBody}") else List.empty) ++
-        (if (responseDetailsData.isTruncated) List(s"response.detail.${EventKeys.ResponseMessage}") else List.empty)
+      (if (requestDetailsData.isTruncated)
+         List(s"request.detail.${EventKeys.RequestBody}")
+       else List.empty) ++
+        (if (responseDetailsData.isTruncated)
+           List(s"response.detail.${EventKeys.ResponseMessage}")
+         else List.empty)
     if (truncatedFields.nonEmpty)
-      logger.info(s"Outbound ${request.verb} ${request.url} - the following fields were truncated for auditing: ${truncatedFields.mkString(", ")}")
-
+      logger.info(
+        s"Outbound ${request.verb} ${request.url} - the following fields were truncated for auditing: ${truncatedFields.mkString(", ")}"
+      )
 
     val redactedFields =
-      (if (requestDetailsData.isRedacted) List(s"request.detail.${EventKeys.RequestBody}") else List.empty) ++
-        (if (responseDetailsData.isRedacted) List(s"response.detail.${EventKeys.ResponseMessage}") else List.empty)
+      (if (requestDetailsData.isRedacted)
+         List(s"request.detail.${EventKeys.RequestBody}")
+       else List.empty) ++
+        (if (responseDetailsData.isRedacted)
+           List(s"response.detail.${EventKeys.ResponseMessage}")
+         else List.empty)
 
     MergedDataEvent(
-      auditSource   = appName,
-      auditType     = outboundCallAuditType,
-      request       = DataCall(
-                        tags        = hc.toAuditTags(request.url),
-                        detail      = requestDetailsData.value,
-                        generatedAt = request.generatedAt
-                      ),
-      response      = DataCall(
-                        tags        = Map.empty,
-                        detail      = responseDetailsData.value,
-                        generatedAt = now()
-                      ),
+      auditSource = appName,
+      auditType = outboundCallAuditType,
+      request = DataCall(
+        tags = hc.toAuditTags(request.url),
+        detail = requestDetailsData.value,
+        generatedAt = request.generatedAt
+      ),
+      response = DataCall(
+        tags = Map.empty,
+        detail = responseDetailsData.value,
+        generatedAt = now()
+      ),
       truncationLog = TruncationLog.of(truncatedFields),
-      redactionLog  = RedactionLog.of(redactedFields)
+      redactionLog = RedactionLog.of(redactedFields)
     )
   }
 
   private def when[K, V](pred: Boolean)(value: => Map[K, V]): Map[K, V] =
     if (pred) value else Map.empty
 
-  private[http] def caseInsensitiveMap(headers: Seq[(String, String)]): SortedMap[String, String] =
+  private[http] def caseInsensitiveMap(
+      headers: Seq[(String, String)]
+  ): SortedMap[String, String] =
     SortedMap()(Ordering.comparatorToOrdering(String.CASE_INSENSITIVE_ORDER)) ++
-      headers.groupBy(_._1.toLowerCase).map{ case (_, hdrs) => hdrs.head._1 -> hdrs.map(_._2).mkString(",")}
+      headers.groupBy(_._1.toLowerCase).map { case (_, hdrs) =>
+        hdrs.head._1 -> hdrs.map(_._2).mkString(",")
+      }
 
-  private def requestDetails(httpRequest: HttpRequest)(implicit hc: HeaderCarrier): Data[Map[String, String]] = {
+  private def requestDetails(
+      httpRequest: HttpRequest
+  )(implicit hc: HeaderCarrier): Data[Map[String, String]] = {
     val maskedRequestBody =
       httpRequest.body.fold(Data.pure(Map.empty[String, String]))(b =>
         b.flatMap(maskRequestBody).map(mrb => Map(EventKeys.RequestBody -> mrb))
@@ -161,11 +182,14 @@ trait HttpAuditing {
     maskedRequestBody.map { mrb =>
       val caseInsensitiveHeaders = caseInsensitiveMap(httpRequest.headers)
       Map(
-        "ipAddress"               -> hc.forwarded.map(_.value).getOrElse("-"),
-        EventKeys.Path            -> httpRequest.url,
-        EventKeys.Method          -> httpRequest.verb
+        "ipAddress"      -> hc.forwarded.map(_.value).getOrElse("-"),
+        EventKeys.Path   -> httpRequest.url,
+        EventKeys.Method -> httpRequest.verb
       ) ++
-        caseInsensitiveHeaders.get(HeaderNames.surrogate).map(HeaderNames.surrogate.toLowerCase -> _).toMap ++ mrb ++
+        caseInsensitiveHeaders
+          .get(HeaderNames.surrogate)
+          .map(HeaderNames.surrogate.toLowerCase -> _)
+          .toMap ++ mrb ++
         when(auditConnector.auditSentHeaders)(
           caseInsensitiveHeaders - HeaderNames.surrogate - HeaderNames.authorisation
         )
@@ -175,10 +199,13 @@ trait HttpAuditing {
   private def maskRequestBody(body: HookData): Data[String] =
     body match {
       case HookData.FromMap(m) =>
-        Data.traverse(m.toSeq) {
-          case (key, _) if shouldMaskField(key) => Data.redacted(key -> MaskValue)
-          case other                            => Data.pure(other)
-        }.map(_.toMap.toString())
+        Data
+          .traverse(m.toSeq) {
+            case (key, _) if shouldMaskField(key) =>
+              Data.redacted(key -> MaskValue)
+            case other => Data.pure(other)
+          }
+          .map(_.toMap.toString())
       case HookData.FromString(s) =>
         maskString(s)
     }
@@ -201,8 +228,9 @@ trait HttpAuditing {
           }
       } catch {
         case _: SAXParseException => Data.pure(text)
-        case e: Throwable         => logger.error(s"Unexpected error parsing xml: ${e.getMessage}", e)
-                                     Data.pure(text)
+        case e: Throwable         =>
+          logger.error(s"Unexpected error parsing xml: ${e.getMessage}", e)
+          Data.pure(text)
       }
     else
       Data.pure(text)
@@ -210,13 +238,15 @@ trait HttpAuditing {
   private def maskJsonFields(json: JsValue): Data[JsValue] =
     json match {
       case JsObject(fields) =>
-          Data.traverse(fields.toSeq) { case (key, value) =>
+        Data
+          .traverse(fields.toSeq) { case (key, value) =>
             if (shouldMaskField(key))
               Data.redacted(key -> JsString(MaskValue))
             else
               maskJsonFields(value).map(key -> _)
-          }.map(JsObject(_))
-      case JsArray(values)   =>
+          }
+          .map(JsObject(_))
+      case JsArray(values) =>
         Data.traverse(values.toSeq)(maskJsonFields).map(JsArray(_))
       case other =>
         Data.pure(other)
@@ -226,10 +256,11 @@ trait HttpAuditing {
     node match {
       case e: Elem =>
         for {
-          child      <- if (shouldMaskField(e.label))
-                          Data.redacted(Seq(Text(MaskValue)))
-                        else
-                          Data.traverse(e.child.toSeq)(maskXMLFields)
+          child <-
+            if (shouldMaskField(e.label))
+              Data.redacted(Seq(Text(MaskValue)))
+            else
+              Data.traverse(e.child.toSeq)(maskXMLFields)
           attributes <- maskXMLAttributes(e.attributes)
         } yield e.copy(child = child, attributes = attributes)
       case other =>
@@ -239,37 +270,59 @@ trait HttpAuditing {
   private def maskXMLAttributes(attributes: MetaData): Data[MetaData] =
     attributes.foldLeft(Data.pure(Null: scala.xml.MetaData)) { (previous, attr) =>
       attr match {
-        case a: PrefixedAttribute   if shouldMaskField(a.key) => Data.redacted(new PrefixedAttribute(a.pre, a.key, MaskValue, previous.value))
-        case a: UnprefixedAttribute if shouldMaskField(a.key) => Data.redacted(new UnprefixedAttribute(a.key, MaskValue, previous.value))
-        case other                                            => previous.flatMap(_ => Data.pure(other))
+        case a: PrefixedAttribute if shouldMaskField(a.key) =>
+          Data.redacted(
+            new PrefixedAttribute(a.pre, a.key, MaskValue, previous.value)
+          )
+        case a: UnprefixedAttribute if shouldMaskField(a.key) =>
+          Data.redacted(
+            new UnprefixedAttribute(a.key, MaskValue, previous.value)
+          )
+        case other => previous.flatMap(_ => Data.pure(other))
       }
     }
 
   private def prettyPrinter() = // not val since is not thread-safe
     new PrettyPrinter(80, 4)
 
-  private def xxeResistantParser() = {  // not val since is not thread-safe
+  private def xxeResistantParser() = { // not val since is not thread-safe
     val saxParserFactory = SAXParserFactory.newInstance()
-    saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false)
-    saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-    saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    saxParserFactory.setFeature(
+      "http://xml.org/sax/features/external-general-entities",
+      false
+    )
+    saxParserFactory.setFeature(
+      "http://apache.org/xml/features/disallow-doctype-decl",
+      true
+    )
+    saxParserFactory.setFeature(
+      "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+      false
+    )
     XML.withSAXParser(saxParserFactory.newSAXParser())
   }
 
   private def isAuditable(url: String) =
-    !url.contains("/write/audit") && auditDisabledForPattern.findFirstIn(url).isEmpty
+    !url.contains("/write/audit") && auditDisabledForPattern
+      .findFirstIn(url)
+      .isEmpty
 
   protected case class HttpRequest(
-    verb       : String,
-    url        : String,
-    headers    : Seq[(String, String)],
-    body       : Option[Data[HookData]],
-    generatedAt: Instant
+      verb: String,
+      url: String,
+      headers: Seq[(String, String)],
+      body: Option[Data[HookData]],
+      generatedAt: Instant
   )
 }
 
 // Used by bootstrap-play
 object HeaderFieldsExtractor {
-  def optionalAuditFieldsSeq(headers: Map[String, Seq[String]]): Map[String, String] =
-    headers.get(HeaderNames.surrogate).map(HeaderNames.surrogate.toLowerCase -> _.mkString(",")).toMap
+  def optionalAuditFieldsSeq(
+      headers: Map[String, Seq[String]]
+  ): Map[String, String] =
+    headers
+      .get(HeaderNames.surrogate)
+      .map(HeaderNames.surrogate.toLowerCase -> _.mkString(","))
+      .toMap
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfig.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.play.audit.http.config
 import scala.language.implicitConversions
 
 case class BaseUri(
-  host    : String,
-  port    : Int,
-  protocol: String
+    host: String,
+    port: Int,
+    protocol: String
 ) {
   val uri: String =
     s"$protocol://$host:$port".stripSuffix("/") + "/"
@@ -31,13 +31,13 @@ case class BaseUri(
 }
 
 case class Consumer(
-  baseUri            : BaseUri,
-  singleEventUri     : String  = "write/audit",
-  mergedEventUri     : String  = "write/audit/merged",
-  largeMergedEventUri: String  = "write/audit/merged/large"
+    baseUri: BaseUri,
+    singleEventUri: String = "write/audit",
+    mergedEventUri: String = "write/audit/merged",
+    largeMergedEventUri: String = "write/audit/merged/large"
 ) {
-  val singleEventUrl     : String = baseUri.addEndpoint(singleEventUri)
-  val mergedEventUrl     : String = baseUri.addEndpoint(mergedEventUri)
+  val singleEventUrl: String      = baseUri.addEndpoint(singleEventUri)
+  val mergedEventUrl: String      = baseUri.addEndpoint(mergedEventUri)
   val largeMergedEventUrl: String = baseUri.addEndpoint(largeMergedEventUri)
 }
 
@@ -47,36 +47,38 @@ object Consumer {
 }
 
 case class AuditingConfig(
-  consumer        : Option[Consumer],
-  enabled         : Boolean,
-  auditSource     : String,
-  auditSentHeaders: Boolean,
-  auditProvider   : Option[String] = None
+    consumer: Option[Consumer],
+    enabled: Boolean,
+    auditSource: String,
+    auditSentHeaders: Boolean,
+    auditProvider: Option[String] = None
 )
 
 object AuditingConfig {
   def fromConfig(configuration: play.api.Configuration): AuditingConfig =
     if (configuration.get[Boolean]("auditing.enabled"))
       AuditingConfig(
-        enabled           = true,
-        consumer          = Some(
-                              Consumer(
-                                BaseUri(
-                                  host     = configuration.get[String]("auditing.consumer.baseUri.host"),
-                                  port     = configuration.get[Int]("auditing.consumer.baseUri.port"),
-                                  protocol = configuration.getOptional[String]("auditing.consumer.baseUri.protocol").getOrElse("http")
-                                )
-                              )
-                            ),
-        auditSource       = configuration.get[String]("appName"),
-        auditSentHeaders  = configuration.get[Boolean]("auditing.auditSentHeaders"),
-        auditProvider     = configuration.get[Option[String]]("auditing.auditProvider")
+        enabled = true,
+        consumer = Some(
+          Consumer(
+            BaseUri(
+              host = configuration.get[String]("auditing.consumer.baseUri.host"),
+              port = configuration.get[Int]("auditing.consumer.baseUri.port"),
+              protocol = configuration
+                .getOptional[String]("auditing.consumer.baseUri.protocol")
+                .getOrElse("http")
+            )
+          )
+        ),
+        auditSource = configuration.get[String]("appName"),
+        auditSentHeaders = configuration.get[Boolean]("auditing.auditSentHeaders"),
+        auditProvider = configuration.get[Option[String]]("auditing.auditProvider")
       )
     else
       AuditingConfig(
-        enabled          = false,
-        consumer         = None,
-        auditSource      = "auditing disabled",
+        enabled = false,
+        consumer = None,
+        auditSource = "auditing disabled",
         auditSentHeaders = false
       )
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannel.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannel.scala
@@ -24,32 +24,33 @@ import uk.gov.hmrc.audit.handler.{AuditHandler, DatastreamHandler, LoggingHandle
 import uk.gov.hmrc.play.audit.http.config.{AuditingConfig, BaseUri, Consumer}
 import uk.gov.hmrc.audit.{HandlerResult, WSClient}
 
-import scala.concurrent.duration.{Duration,DurationInt}
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 
 trait AuditChannel {
-  def auditingConfig   : AuditingConfig
-  def materializer     : Materializer
-  def lifecycle        : ApplicationLifecycle
+  def auditingConfig: AuditingConfig
+  def materializer: Materializer
+  def lifecycle: ApplicationLifecycle
   def datastreamMetrics: DatastreamMetrics
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
   val defaultConnectionTimeout: Duration = 5000.millis
-  val defaultRequestTimeout   : Duration = 5000.millis
+  val defaultRequestTimeout: Duration    = 5000.millis
 
   val defaultBaseUri = BaseUri("datastream.protected.mdtp", 90, "http")
 
-  lazy val consumer: Consumer = auditingConfig.consumer.getOrElse(Consumer(defaultBaseUri))
+  lazy val consumer: Consumer =
+    auditingConfig.consumer.getOrElse(Consumer(defaultBaseUri))
 
   lazy val baseUri: BaseUri = consumer.baseUri
 
   private lazy val wsClient: WSClient = {
     implicit val m = materializer
-    val wsClient = WSClient(
+    val wsClient   = WSClient(
       connectTimeout = defaultConnectionTimeout,
       requestTimeout = defaultRequestTimeout,
-      userAgent      = auditingConfig.auditSource
+      userAgent = auditingConfig.auditSource
     )
     lifecycle.addStopHook { () =>
       logger.info("Closing play-auditing http connections...")
@@ -71,15 +72,17 @@ trait AuditChannel {
 
   lazy val loggingConnector: AuditHandler = LoggingHandler
 
-  def send(path:String, event: JsValue)(implicit ec: ExecutionContext): Future[HandlerResult] =
-    datastreamHandler(path).sendEvent(event)
+  def send(path: String, event: JsValue)(implicit
+      ec: ExecutionContext
+  ): Future[HandlerResult] =
+    datastreamHandler(path)
+      .sendEvent(event)
       .flatMap {
         case HandlerResult.Failure => loggingConnector.sendEvent(event)
         case result                => Future.successful(result)
       }
-      .recover {
-        case e: Throwable =>
-          logger.error("Error in handler code", e)
-          HandlerResult.Failure
+      .recover { case e: Throwable =>
+        logger.error("Error in handler code", e)
+        HandlerResult.Failure
       }
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 
 import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.audit.model.ValidatedDataEvent
 
 sealed trait AuditResult
 object AuditResult {
@@ -68,7 +69,7 @@ trait AuditConnector {
       ec: ExecutionContext,
       writes: AuditFormat[T]
   ): Unit = {
-    given OFormat[T] = writes.format
+    implicit val f: OFormat[T] = writes.format
     sendExplicitAudit(auditType, Json.toJson(detail).as[JsObject])
   }
 
@@ -102,6 +103,17 @@ trait AuditConnector {
         )
       )
     }
+
+  def sendValidatedEvent[T](event: ValidatedDataEvent[T])(implicit
+      hc: HeaderCarrier = HeaderCarrier(),
+      ec: ExecutionContext,
+      auditFormat: AuditFormat[T]
+  ): Future[AuditResult] = {
+    import io.scalaland.chimney.dsl._
+    implicit val oformat: OFormat[T]  = auditFormat.format
+    val extendedEvent = event.into[ExtendedDataEvent].withFieldComputed(_.detail, v => Json.toJson(v.detail)).transform
+    sendExtendedEvent(extendedEvent)
+  }
 
   def sendExtendedEvent(event: ExtendedDataEvent)(implicit
       hc: HeaderCarrier = HeaderCarrier(),

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.json.OFormat
 
 sealed trait AuditResult
 object AuditResult {
@@ -66,8 +67,10 @@ trait AuditConnector {
       hc: HeaderCarrier,
       ec: ExecutionContext,
       writes: AuditFormat[T]
-  ): Unit =
+  ): Unit = {
+    given OFormat[T] = writes.format
     sendExplicitAudit(auditType, Json.toJson(detail).as[JsObject])
+  }
 
   private def sendExplicitAudit(auditType: String, detail: JsObject)(implicit
       hc: HeaderCarrier,

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.play.audit.http.connector
 
 import java.util.UUID
-
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json.{JsObject, Json, Writes}
 import uk.gov.hmrc.audit.HandlerResult
@@ -26,14 +25,17 @@ import uk.gov.hmrc.play.audit.http.config.AuditingConfig
 import uk.gov.hmrc.play.audit.model.{DataEvent, ExtendedDataEvent, MergedDataEvent}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
+import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 
 import scala.concurrent.{ExecutionContext, Future}
 
 sealed trait AuditResult
 object AuditResult {
-  case object Success extends AuditResult
+  case object Success  extends AuditResult
   case object Disabled extends AuditResult
-  case class Failure(msg: String, nested: Option[Throwable] = None) extends Exception(msg, nested.orNull) with AuditResult
+  case class Failure(msg: String, nested: Option[Throwable] = None)
+      extends Exception(msg, nested.orNull)
+      with AuditResult
 
   def fromHandlerResult(result: HandlerResult): AuditResult =
     result match {
@@ -45,7 +47,7 @@ object AuditResult {
 
 trait AuditConnector {
   def auditingConfig: AuditingConfig
-  def auditChannel  : AuditChannel
+  def auditChannel: AuditChannel
   def datastreamMetrics: DatastreamMetrics
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -54,51 +56,78 @@ trait AuditConnector {
 
   lazy val auditSerialiser: AuditSerialiserLike = AuditSerialiser
 
-  def sendExplicitAudit(auditType: String, detail: Map[String, String])(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit =
+  def sendExplicitAudit(auditType: String, detail: Map[String, String])(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext
+  ): Unit =
     sendExplicitAudit(auditType, Json.toJson(detail).as[JsObject])
 
-  def sendExplicitAudit[T](auditType: String, detail: T)(implicit hc: HeaderCarrier, ec: ExecutionContext, writes: Writes[T]): Unit =
+  def sendExplicitAudit[T](auditType: String, detail: T)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      writes: AuditFormat[T]
+  ): Unit =
     sendExplicitAudit(auditType, Json.toJson(detail).as[JsObject])
 
-  def sendExplicitAudit(auditType: String, detail: JsObject)(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit =
+  private def sendExplicitAudit(auditType: String, detail: JsObject)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext
+  ): Unit =
     sendExtendedEvent(
       ExtendedDataEvent(
         auditProvider = auditingConfig.auditProvider,
-        auditSource   = auditingConfig.auditSource,
-        auditType     = auditType,
-        eventId       = UUID.randomUUID().toString,
-        tags          = hc.toAuditTags(),
-        detail        = detail
+        auditSource = auditingConfig.auditSource,
+        auditType = auditType,
+        eventId = UUID.randomUUID().toString,
+        tags = hc.toAuditTags(),
+        detail = detail
       )
     )
 
-  def sendEvent(event: DataEvent)(implicit hc: HeaderCarrier = HeaderCarrier(), ec: ExecutionContext): Future[AuditResult] =
+  def sendEvent(event: DataEvent)(implicit
+      hc: HeaderCarrier = HeaderCarrier(),
+      ec: ExecutionContext
+  ): Future[AuditResult] =
     ifEnabled {
       send(
         "/write/audit",
-        auditSerialiser.serialise(event.copy(
-          auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider),
-          tags = hc.appendToDefaultTags(event.tags)))
+        auditSerialiser.serialise(
+          event.copy(
+            auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider),
+            tags = hc.appendToDefaultTags(event.tags)
+          )
         )
-    }
-
-  def sendExtendedEvent(event: ExtendedDataEvent)(implicit hc: HeaderCarrier = HeaderCarrier(), ec: ExecutionContext): Future[AuditResult] =
-    ifEnabled {
-      send(
-         "/write/audit",
-        auditSerialiser.serialise(event.copy(
-          auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider),
-          tags = hc.appendToDefaultTags(event.tags)))
       )
     }
 
-  def sendMergedEvent(event: MergedDataEvent)(implicit hc: HeaderCarrier = HeaderCarrier(), ec: ExecutionContext): Future[AuditResult] =
+  def sendExtendedEvent(event: ExtendedDataEvent)(implicit
+      hc: HeaderCarrier = HeaderCarrier(),
+      ec: ExecutionContext
+  ): Future[AuditResult] =
+    ifEnabled {
+      send(
+        "/write/audit",
+        auditSerialiser.serialise(
+          event.copy(
+            auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider),
+            tags = hc.appendToDefaultTags(event.tags)
+          )
+        )
+      )
+    }
+
+  def sendMergedEvent(event: MergedDataEvent)(implicit
+      hc: HeaderCarrier = HeaderCarrier(),
+      ec: ExecutionContext
+  ): Future[AuditResult] =
     ifEnabled {
       send(
         "/write/audit/merged",
-        auditSerialiser.serialise(event.copy(
-          auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider)
-        ))
+        auditSerialiser.serialise(
+          event.copy(
+            auditProvider = event.auditProvider.orElse(auditingConfig.auditProvider)
+          )
+        )
       )
     }
 
@@ -109,14 +138,20 @@ trait AuditConnector {
     enabled
   }
 
-  private def ifEnabled(send: => Future[HandlerResult])(implicit ec: ExecutionContext): Future[AuditResult] =
+  private def ifEnabled(
+      send: => Future[HandlerResult]
+  )(implicit ec: ExecutionContext): Future[AuditResult] =
     if (isEnabled)
       send.map(AuditResult.fromHandlerResult)
     else
       Future.successful(AuditResult.Disabled)
 
-  private[connector] def send(path:String, audit:JsObject)(implicit ec: ExecutionContext): Future[HandlerResult] = {
-    val metadata = Json.obj("metadata" -> Json.obj("metricsKey" -> datastreamMetrics.metricsKey))
+  private[connector] def send(path: String, audit: JsObject)(implicit
+      ec: ExecutionContext
+  ): Future[HandlerResult] = {
+    val metadata = Json.obj(
+      "metadata" -> Json.obj("metricsKey" -> datastreamMetrics.metricsKey)
+    )
     auditChannel.send(path, audit ++ metadata)
   }
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -110,7 +110,7 @@ trait AuditConnector {
       auditFormat: AuditFormat[T]
   ): Future[AuditResult] = {
     import io.scalaland.chimney.dsl._
-    implicit val oformat: OFormat[T]  = auditFormat.format
+    implicit val oformat: OFormat[T] = auditFormat.format
     val extendedEvent = event.into[ExtendedDataEvent].withFieldComputed(_.detail, v => Json.toJson(v.detail)).transform
     sendExtendedEvent(extendedEvent)
   }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/DatastreamMetrics.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/connector/DatastreamMetrics.scala
@@ -21,10 +21,10 @@ trait Counter {
 }
 
 case class DatastreamMetrics(
-  successCounter: Counter,
-  rejectCounter : Counter,
-  failureCounter: Counter,
-  metricsKey    : Option[String] // not present if metrics are disabled
+    successCounter: Counter,
+    rejectCounter: Counter,
+    failureCounter: Counter,
+    metricsKey: Option[String] // not present if metrics are disabled
 )
 
 object DatastreamMetrics {
@@ -35,16 +35,16 @@ object DatastreamMetrics {
   lazy val disabled: DatastreamMetrics =
     DatastreamMetrics(
       successCounter = DisabledCounter,
-      rejectCounter  = DisabledCounter,
+      rejectCounter = DisabledCounter,
       failureCounter = DisabledCounter,
-      metricsKey     = None
+      metricsKey = None
     )
 
   def apply(prefix: String, mkCounter: String => Counter): DatastreamMetrics =
     DatastreamMetrics(
       successCounter = mkCounter("audit.success"),
-      rejectCounter  = mkCounter("audit.reject"),
+      rejectCounter = mkCounter("audit.reject"),
       failureCounter = mkCounter("audit.failure"),
-      metricsKey     = Some(prefix)
+      metricsKey = Some(prefix)
     )
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/validation/AuditFormat.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/validation/AuditFormat.scala
@@ -16,10 +16,6 @@
 
 package uk.gov.hmrc.play.audit.http.validation
 
-import play.api.libs.json.{JsObject, JsResult, JsValue, OFormat}
+import play.api.libs.json.OFormat
 
-class AuditFormat[T](format: OFormat[T]) extends OFormat[T] {
-  override def writes(o: T): JsObject = format.writes(o)
-
-  override def reads(json: JsValue): JsResult[T] = format.reads(json)
-}
+class AuditFormat[T](val format: OFormat[T])

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/validation/AuditFormat.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/http/validation/AuditFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.audit
+package uk.gov.hmrc.play.audit.http.validation
 
-import org.scalatestplus.mockito.MockitoSugar.mock
-import uk.gov.hmrc.play.audit.http.connector.{DatastreamMetrics, Counter}
+import play.api.libs.json.{JsObject, JsResult, JsValue, OFormat}
 
-trait DatastreamMetricsMock {
+class AuditFormat[T](format: OFormat[T]) extends OFormat[T] {
+  override def writes(o: T): JsObject = format.writes(o)
 
-  def mockDatastreamMetrics(metricsKey: Option[String]): DatastreamMetrics =
-    DatastreamMetrics(
-      mock[Counter],
-      mock[Counter],
-      mock[Counter],
-      metricsKey
-    )
+  override def reads(json: JsValue): JsResult[T] = format.reads(json)
 }

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/Audit.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/Audit.scala
@@ -33,7 +33,14 @@ sealed trait AuditAsMagnet[A] {
   val outputTransformer: OutputTransformer[A]
   val eventTypes: (String, String)
 
-  def apply(f: (String, Map[String, String], OutputTransformer[A], (String, String)) => A): A =
+  def apply(
+      f: (
+          String,
+          Map[String, String],
+          OutputTransformer[A],
+          (String, String)
+      ) => A
+  ): A =
     f(txName, inputs, outputTransformer, eventTypes)
 }
 
@@ -41,34 +48,48 @@ object AuditAsMagnet {
 
   import uk.gov.hmrc.play.audit.model.Audit.{EventTypeFlowDescriptions, OutputTransformer, defaultEventTypes}
 
-  implicit def inputAsStringDefaultEventTypes[A](parms: (String, String, OutputTransformer[A])): AuditAsMagnet[A] =
+  implicit def inputAsStringDefaultEventTypes[A](
+      parms: (String, String, OutputTransformer[A])
+  ): AuditAsMagnet[A] =
     auditAsMagnet(parms._1, Map("" -> parms._2), defaultEventTypes, parms._3)
 
-  implicit def inputAsString[A](parms: (String, String, EventTypeFlowDescriptions, OutputTransformer[A])): AuditAsMagnet[A] =
+  implicit def inputAsString[A](
+      parms: (String, String, EventTypeFlowDescriptions, OutputTransformer[A])
+  ): AuditAsMagnet[A] =
     auditAsMagnet(parms._1, Map("" -> parms._2), parms._3, parms._4)
 
-  implicit def inputAsMapDefaultEventTypes[A](parms: (String, Map[String, String], OutputTransformer[A])): AuditAsMagnet[A] =
+  implicit def inputAsMapDefaultEventTypes[A](
+      parms: (String, Map[String, String], OutputTransformer[A])
+  ): AuditAsMagnet[A] =
     auditAsMagnet(parms._1, parms._2, defaultEventTypes, parms._3)
 
-  implicit def inputAsMap[A](parms: (String, Map[String, String], EventTypeFlowDescriptions, OutputTransformer[A])): AuditAsMagnet[A] =
+  implicit def inputAsMap[A](
+      parms: (
+          String,
+          Map[String, String],
+          EventTypeFlowDescriptions,
+          OutputTransformer[A]
+      )
+  ): AuditAsMagnet[A] =
     auditAsMagnet(parms._1, parms._2, parms._3, parms._4)
 
   private def auditAsMagnet[A](
       txN: String,
       ins: Map[String, String],
       et: EventTypeFlowDescriptions,
-      ot: OutputTransformer[A]) =
+      ot: OutputTransformer[A]
+  ) =
     new AuditAsMagnet[A] {
-      val txName = txN
-      val inputs = ins
+      val txName            = txN
+      val inputs            = ins
       val outputTransformer = ot
-      val eventTypes = et
+      val eventTypes        = et
     }
 }
 
 object EventTypes {
   val Succeeded = "TxSucceeded"
-  val Failed = "TxFailed"
+  val Failed    = "TxFailed"
 }
 
 object Audit {
@@ -86,7 +107,7 @@ object Audit {
 }
 
 trait AuditTags {
-  val xRequestId = "X-Request-ID"
+  val xRequestId      = "X-Request-ID"
   val TransactionName = "transactionName"
 }
 
@@ -96,70 +117,90 @@ class Audit(applicationName: String, auditConnector: AuditConnector) extends Aud
   def sendDataEvent(de: DataEvent)(implicit ec: ExecutionContext): Unit =
     auditConnector.sendEvent(de)
 
-  def sendMergedDataEvent(de: MergedDataEvent)(implicit ec: ExecutionContext): Unit =
+  def sendMergedDataEvent(de: MergedDataEvent)(implicit
+      ec: ExecutionContext
+  ): Unit =
     auditConnector.sendMergedEvent(de)
 
   private def sendEvent[A](
-    auditMagnet: AuditAsMagnet[A],
-    eventType  : String,
-    outputs    : Map[String, String]
+      auditMagnet: AuditAsMagnet[A],
+      eventType: String,
+      outputs: Map[String, String]
   )(implicit
-    hc: HeaderCarrier,
-    ec: ExecutionContext
+      hc: HeaderCarrier,
+      ec: ExecutionContext
   ): Unit = {
     val requestId = hc.requestId.map(_.value).getOrElse("")
-    sendDataEvent(DataEvent(
-      auditSource = applicationName,
-      auditType   = eventType,
-      tags        = Map(
-                      xRequestId -> requestId,
-                      TransactionName -> auditMagnet.txName
-                    ),
-      detail      = auditMagnet.inputs.map(inputKeys) ++ outputs
-    ))
+    sendDataEvent(
+      DataEvent(
+        auditSource = applicationName,
+        auditType = eventType,
+        tags = Map(
+          xRequestId      -> requestId,
+          TransactionName -> auditMagnet.txName
+        ),
+        detail = auditMagnet.inputs.map(inputKeys) ++ outputs
+      )
+    )
   }
 
   private def givenResultSendAuditEvent[A](
-    auditMagnet: AuditAsMagnet[A]
+      auditMagnet: AuditAsMagnet[A]
   )(implicit
-    hc: HeaderCarrier,
-    ec: ExecutionContext
+      hc: HeaderCarrier,
+      ec: ExecutionContext
   ): PartialFunction[TransactionResult, Unit] = {
-    case TransactionSuccess(m)    => sendEvent(auditMagnet, auditMagnet.eventTypes._1, m.map(outputKeys))
-    case TransactionFailure(r, m) => sendEvent(auditMagnet, auditMagnet.eventTypes._2, r.map(reason => Map("transactionFailureReason" -> reason)).getOrElse(Map.empty) ++ m.map(outputKeys))
+    case TransactionSuccess(m) =>
+      sendEvent(auditMagnet, auditMagnet.eventTypes._1, m.map(outputKeys))
+    case TransactionFailure(r, m) =>
+      sendEvent(
+        auditMagnet,
+        auditMagnet.eventTypes._2,
+        r.map(reason => Map("transactionFailureReason" -> reason))
+          .getOrElse(Map.empty) ++ m.map(outputKeys)
+      )
   }
 
-  def asyncAs[A](auditMagnet: AuditAsMagnet[A])(body: AsyncBody[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
+  def asyncAs[A](auditMagnet: AuditAsMagnet[A])(
+      body: AsyncBody[A]
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
     val invokedBody: Future[A] =
       try { body() }
       catch { case e: Exception => Future.failed[A](e) }
 
     invokedBody
-      .map ( auditMagnet.outputTransformer )
-      .recover { case e: Exception => TransactionFailure(s"Exception Generated: ${e.getMessage}") }
-      .map ( givenResultSendAuditEvent(auditMagnet) )
+      .map(auditMagnet.outputTransformer)
+      .recover { case e: Exception =>
+        TransactionFailure(s"Exception Generated: ${e.getMessage}")
+      }
+      .map(givenResultSendAuditEvent(auditMagnet))
 
     invokedBody
   }
 
-  def as[A](auditMagnet: AuditAsMagnet[A])(body: Body[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): A = {
+  def as[A](
+      auditMagnet: AuditAsMagnet[A]
+  )(body: Body[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): A = {
     val result: Try[A] = Try(body())
 
     result
       .map(auditMagnet.outputTransformer)
-      .recover { case e: Exception => TransactionFailure(s"Exception Generated: ${ e.getMessage }") }
+      .recover { case e: Exception =>
+        TransactionFailure(s"Exception Generated: ${e.getMessage}")
+      }
       .map(givenResultSendAuditEvent(auditMagnet))
 
     result.get
   }
 
-  private val inputKeys = prependKeysWith("input") _
+  private val inputKeys  = prependKeysWith("input") _
   private val outputKeys = prependKeysWith("output") _
 
-  private def prependKeysWith(prefix: String)(entry: (String, String)) = entry match {
-    case ("", value) => prefix -> value
-    case (key, value) => s"$prefix-$key" -> value
-  }
+  private def prependKeysWith(prefix: String)(entry: (String, String)) =
+    entry match {
+      case ("", value)  => prefix          -> value
+      case (key, value) => s"$prefix-$key" -> value
+    }
 }
 
 sealed trait TransactionResult {
@@ -167,8 +208,8 @@ sealed trait TransactionResult {
 }
 
 case class TransactionFailure(
-  reason : Option[String] = None,
-  outputs: Map[String, String] = Map()
+    reason: Option[String] = None,
+    outputs: Map[String, String] = Map()
 ) extends TransactionResult
 
 object TransactionFailure {
@@ -180,7 +221,7 @@ object TransactionFailure {
 }
 
 case class TransactionSuccess(
-  outputs: Map[String, String] = Map()
+    outputs: Map[String, String] = Map()
 ) extends TransactionResult
 
 object TransactionSuccess {

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
@@ -22,44 +22,44 @@ import java.time.Instant
 import play.api.libs.json._
 
 case class DataEvent(
-  auditSource  : String,
-  auditType    : String,
-  eventId      : String              = UUID.randomUUID().toString,
-  tags         : Map[String, String] = Map.empty,
-  detail       : Map[String, String] = Map.empty,
-  generatedAt  : Instant             = Instant.now(),
-  truncationLog: TruncationLog       = TruncationLog.Empty,
-  redactionLog : RedactionLog        = RedactionLog.Empty,
-  auditProvider: Option[String]      = None
+    auditSource: String,
+    auditType: String,
+    eventId: String = UUID.randomUUID().toString,
+    tags: Map[String, String] = Map.empty,
+    detail: Map[String, String] = Map.empty,
+    generatedAt: Instant = Instant.now(),
+    truncationLog: TruncationLog = TruncationLog.Empty,
+    redactionLog: RedactionLog = RedactionLog.Empty,
+    auditProvider: Option[String] = None
 )
 
 case class ExtendedDataEvent(
-  auditSource  : String,
-  auditType    : String,
-  eventId      : String              = UUID.randomUUID().toString,
-  tags         : Map[String, String] = Map.empty,
-  detail       : JsValue             = JsString(""),
-  generatedAt  : Instant             = Instant.now(),
-  truncationLog: TruncationLog       = TruncationLog.Empty,
-  redactionLog : RedactionLog        = RedactionLog.Empty,
-  auditProvider: Option[String]      = None
+    auditSource: String,
+    auditType: String,
+    eventId: String = UUID.randomUUID().toString,
+    tags: Map[String, String] = Map.empty,
+    detail: JsValue = JsString(""),
+    generatedAt: Instant = Instant.now(),
+    truncationLog: TruncationLog = TruncationLog.Empty,
+    redactionLog: RedactionLog = RedactionLog.Empty,
+    auditProvider: Option[String] = None
 )
 
 case class DataCall(
-  tags       : Map[String, String],
-  detail     : Map[String, String],
-  generatedAt: Instant
+    tags: Map[String, String],
+    detail: Map[String, String],
+    generatedAt: Instant
 )
 
 case class MergedDataEvent(
-  auditSource  : String,
-  auditType    : String,
-  eventId      : String         = UUID.randomUUID().toString,
-  request      : DataCall,
-  response     : DataCall,
-  truncationLog: TruncationLog  = TruncationLog.Empty,
-  redactionLog : RedactionLog   = RedactionLog.Empty,
-  auditProvider: Option[String] = None
+    auditSource: String,
+    auditType: String,
+    eventId: String = UUID.randomUUID().toString,
+    request: DataCall,
+    response: DataCall,
+    truncationLog: TruncationLog = TruncationLog.Empty,
+    redactionLog: RedactionLog = RedactionLog.Empty,
+    auditProvider: Option[String] = None
 )
 
 sealed trait TruncationLog {
@@ -67,7 +67,7 @@ sealed trait TruncationLog {
 
   final def asEntry: Option[TruncationLog.Entry] =
     this match {
-      case TruncationLog.Empty => None
+      case TruncationLog.Empty                             => None
       case entry @ TruncationLog.Entry(truncatedFields, _) =>
         if (truncatedFields.nonEmpty)
           Some(entry)
@@ -83,8 +83,8 @@ object TruncationLog {
   }
 
   case class Entry(
-    truncatedFields: List[String],
-    timestamp      : Instant      = Instant.now()
+      truncatedFields: List[String],
+      timestamp: Instant = Instant.now()
   ) extends TruncationLog
 
   def of(truncatedFields: List[String]): TruncationLog =
@@ -105,8 +105,8 @@ object RedactionLog {
   }
 
   case class Entry(
-    redactedFields: List[String],
-    timestamp     : Instant      = Instant.now()
+      redactedFields: List[String],
+      timestamp: Instant = Instant.now()
   ) extends RedactionLog
 
   def of(redactedFields: List[String]): RedactionLog =

--- a/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
+++ b/play-auditing-play-30/src/main/scala/uk/gov/hmrc/play/audit/model/DataEvent.scala
@@ -45,6 +45,18 @@ case class ExtendedDataEvent(
     auditProvider: Option[String] = None
 )
 
+case class ValidatedDataEvent[T](
+    auditSource: String,
+    auditType: String,
+    eventId: String = UUID.randomUUID().toString,
+    tags: Map[String, String] = Map.empty,
+    detail: T,
+    generatedAt: Instant = Instant.now(),
+    truncationLog: TruncationLog = TruncationLog.Empty,
+    redactionLog: RedactionLog = RedactionLog.Empty,
+    auditProvider: Option[String] = None
+)
+
 case class DataCall(
     tags: Map[String, String],
     detail: Map[String, String],

--- a/play-auditing-play-30/src/test/resources/subscription-schema.json
+++ b/play-auditing-play-30/src/test/resources/subscription-schema.json
@@ -27,11 +27,13 @@
         },
         "postcode": {
           "type": "string"
+        }, "country": {
+          "type": "string"
         }
       },
       "required": [
         "street",
-        "postcode"
+        "postcode", "country"
       ],
       "additionalProperties": false
     }

--- a/play-auditing-play-30/src/test/resources/subscription-schema.json
+++ b/play-auditing-play-30/src/test/resources/subscription-schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "Personal information",
+  "properties": {
+    "age": {
+      "type": "number",
+      "description": "Age in years"
+    },
+    "name": {
+      "type": "string",
+      "description": "name of the person"
+    },
+    "list": {
+      "type": "array"
+    },
+    "set": {
+      "type": "array"
+    },
+    "address": {
+      "type": "object",
+      "description": "Address information",
+      "properties": {
+        "street": {
+          "type": "string",
+          "description": "Street address"
+        },
+        "postcode": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "street",
+        "postcode"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "name",
+    "age",
+    "list",
+    "set",
+    "address"
+  ]
+}

--- a/play-auditing-play-30/src/test/resources/subscription-schema.json
+++ b/play-auditing-play-30/src/test/resources/subscription-schema.json
@@ -27,22 +27,14 @@
         },
         "postcode": {
           "type": "string"
-        }, "country": {
+        },
+        "country": {
           "type": "string"
         }
       },
-      "required": [
-        "street",
-        "postcode", "country"
-      ],
+      "required": ["street", "postcode", "country"],
       "additionalProperties": false
     }
   },
-  "required": [
-    "name",
-    "age",
-    "list",
-    "set",
-    "address"
-  ]
+  "required": ["name", "age", "list", "set", "address"]
 }

--- a/play-auditing-play-30/src/test/scala-2.13/uk/gov/hmrc/play/audit/http/validation/AuditMacrosTest.scala
+++ b/play-auditing-play-30/src/test/scala-2.13/uk/gov/hmrc/play/audit/http/validation/AuditMacrosTest.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.play.audit.http.validation
 
 
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.*
+import org.scalatest.matchers.should._
 import org.scalatest.{Inside, Inspectors}
 
 import scala.language.postfixOps

--- a/play-auditing-play-30/src/test/scala-2.13/uk/gov/hmrc/play/audit/http/validation/AuditMacrosTest.scala
+++ b/play-auditing-play-30/src/test/scala-2.13/uk/gov/hmrc/play/audit/http/validation/AuditMacrosTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.validation
+
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.*
+import org.scalatest.{Inside, Inspectors}
+
+import scala.language.postfixOps
+
+class AuditMacrosTest extends AnyFunSuite with Inside with Inspectors with Matchers {
+
+    test("AuditMacros should create audit format"){
+
+
+
+    }
+
+    test("AuditMacros should fail if annotation is missing"){
+        fail("Missing annotation")
+    }
+
+
+}

--- a/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/connector/AuditConnectorValidationSpec.scala
+++ b/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/connector/AuditConnectorValidationSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.connector
+
+import java.time.Instant
+import org.apache.pekko.actor.ActorSystem
+import org.mockito.Mockito.{verify, verifyNoMoreInteractions, when}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.scalatest._
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsNull, JsObject, JsValue, Json}
+import uk.gov.hmrc.audit.{DatastreamMetricsMock, HandlerResult}
+import uk.gov.hmrc.http.{HeaderCarrier, SessionId}
+import uk.gov.hmrc.play.audit.http.config.{AuditingConfig, BaseUri, Consumer}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult._
+import uk.gov.hmrc.play.audit.model.{DataCall, DataEvent, ExtendedDataEvent, MergedDataEvent}
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.audit.http.validation.AuditFormat
+import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
+import uk.gov.hmrc.play.audit.model.ValidatedDataEvent
+import uk.gov.hmrc.play.audit.http.validation.AuditEventSchema
+
+@CipAuditEventUnvalidated
+case class MyExampleAudit(userType: String, vrn: String)
+
+object MyExampleAudit{
+  implicit val format: AuditFormat[MyExampleAudit] = AuditEventSchema.unvalidatedFormat
+}
+class AuditConnectorValidationSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with MockitoSugar
+    with OneInstancePerTest
+    with DatastreamMetricsMock {
+
+  implicit val ec: ExecutionContext = RunInlineExecutionContext
+  implicit val as: ActorSystem      = ActorSystem()
+
+  private val consumer = Consumer(BaseUri("datastream-base-url", 8080, "http"))
+
+  private val enabledConfig = AuditingConfig(
+    consumer = Some(consumer),
+    enabled = true,
+    auditSource = "the-project-name",
+    auditSentHeaders = false
+  )
+  private val enabledConfigWithProvider =
+    enabledConfig.copy(auditProvider = Some("config-provider"))
+
+  private val mockAuditChannel: AuditChannel = mock[AuditChannel]
+  when(mockAuditChannel.send(any[String], any[JsValue])(any[ExecutionContext]))
+    .thenReturn(Future.successful(HandlerResult.Success))
+
+  private def createConnector(
+      config: AuditingConfig,
+      metricsKey: Option[String] = Some("play.the-project-name")
+  ): AuditConnector =
+    new AuditConnector {
+      override def auditingConfig    = config
+      override def auditChannel      = mockAuditChannel
+      override def datastreamMetrics = mockDatastreamMetrics(metricsKey)
+    }
+
+  "sendValidatedEvent" should {
+    val subscription =
+      Subscription("John", 25, List("one"), Set("two"), Address("nowhere avenue", "AB12 3CD", Option("UK")))
+
+    val validatedEvent = ValidatedDataEvent("source", "type", detail = subscription)
+
+    "send a validated event" in {
+      createConnector(enabledConfig).sendValidatedEvent(validatedEvent).futureValue shouldBe AuditResult.Success
+
+      val captor = ArgumentCaptor.forClass(classOf[JsValue])
+
+      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
+
+      // val capturedValue = captor.getValue()
+    }
+  }
+}

--- a/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
+++ b/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
@@ -21,9 +21,8 @@ import play.api.libs.json.OFormat
 import play.api.libs.json.Json
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 import uk.gov.hmrc.play.audit.http.validation.AuditEventSchema
-import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
 
-@CipAuditEventUnvalidated
+@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
 case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
 
 case class Address(street: String, postcode: String, country: Option[String])
@@ -32,5 +31,5 @@ object Address {
   implicit val format: OFormat[Address] = Json.format[Address]
 }
 object Subscription {
-  implicit val format: AuditFormat[Subscription] = AuditEventSchema.unvalidatedFormat[Subscription]
+  implicit val format: AuditFormat[Subscription] = AuditEventSchema.format[Subscription]
 }

--- a/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacroTest.scala
+++ b/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacroTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.validation
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.*
+import org.scalatest.{Inside, Inspectors}
+
+import scala.language.postfixOps
+
+class JsonValidatorMacroTest extends AnyFunSuite with Inside with Inspectors with Matchers:
+
+  test("missing annotation") {
+    """import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
+      |import play.api.libs.json.{Json, OFormat}
+
+      |case class Subscription(name: String, age: Int, address: Address)
+
+      |case class Address(street: String, postcode: String)
+
+      |object Address:
+      |  implicit val format: OFormat[Address] = Json.format[Address]
+
+      |object Subscription:
+      |  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]""".stripMargin shouldNot compile
+  }
+
+  test("Schema file not found") {
+    """
+    |import play.api.libs.json.Json
+    |import play.api.libs.json.OFormat
+    |import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+
+    |@CipAuditEventSchema(schemaFile = "/subscription-schema-not-found.json")
+    |case class Subscription(name: String, age: Int, address: Address)
+
+    |case class Address(street: String, postcode: String)
+
+    |object Address:
+    |  implicit val format: OFormat[Address] = Json.format[Address]
+
+    |object Subscription:
+    |  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]""".stripMargin shouldNot compile
+  }
+
+  test("Missing field") {
+    """
+      |
+    |import play.api.libs.json.Json
+    |import play.api.libs.json.OFormat
+    |import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+
+    |@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
+    |case class Subscription(name: String, age: Int, address: Address, list: List[String], set: Set[String])
+
+    |case class Address(street: String)
+
+    |object Address:
+    |  implicit val format: OFormat[Address] = Json.format[Address]
+
+    |object Subscription:
+    |  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]""".stripMargin shouldNot compile
+  }
+
+  test("no compilation errors") {
+    """
+
+      |import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
+      |import play.api.libs.json.{Json, OFormat}
+      |import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+
+      |@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
+      |case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
+
+      |case class Address(street: String, postcode: String)
+
+      |object Address:
+      |  implicit val format: OFormat[Address] = Json.format[Address]
+
+      |object Subscription:
+      |  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]""".stripMargin should compile
+  }
+
+  test("additional property") {
+    """
+      |
+      |import uk.gov.hmrc.play.audit.http.validation.{JsonValidatorMacro}
+      |import play.api.libs.json.{Json, OFormat}
+      |import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+
+      |@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
+      |case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
+
+      |case class Address(street: String, postcode: String, country: Option[String])
+
+      |object Address:
+      |  implicit val format: OFormat[Address] = Json.format[Address]
+
+      |object Subscription:
+      |  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]""".stripMargin shouldNot compile
+  }

--- a/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacroTest.scala
+++ b/play-auditing-play-30/src/test/scala-3/uk/gov/hmrc/play/audit/http/validation/JsonValidatorMacroTest.scala
@@ -86,7 +86,7 @@ class JsonValidatorMacroTest extends AnyFunSuite with Inside with Inspectors wit
       |@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
       |case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
 
-      |case class Address(street: String, postcode: String)
+      |case class Address(street: String, postcode: String, country: Option[String])
 
       |object Address:
       |  implicit val format: OFormat[Address] = Json.format[Address]
@@ -105,7 +105,7 @@ class JsonValidatorMacroTest extends AnyFunSuite with Inside with Inspectors wit
       |@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
       |case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
 
-      |case class Address(street: String, postcode: String, country: Option[String])
+      |case class Address(street: String, road: String, postcode: String, country: Option[String])
 
       |object Address:
       |  implicit val format: OFormat[Address] = Json.format[Address]

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/WireMockUtils.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/WireMockUtils.scala
@@ -19,10 +19,9 @@ package uk.gov.hmrc.audit
 import java.io.IOException
 import java.net.ServerSocket
 
-
 object WireMockUtils {
   def availablePort(): Int = {
-    var port = 9876
+    var port                 = 9876
     var socket: ServerSocket = null
 
     try {

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/DatastreamHandlerUnitSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/DatastreamHandlerUnitSpec.scala
@@ -30,12 +30,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import ExecutionContext.Implicits.global
 
 class DatastreamHandlerUnitSpec
-  extends AnyWordSpec
-     with Inspectors
-     with Matchers
-     with ScalaFutures
-     with MockitoSugar
-     with DatastreamMetricsMock {
+    extends AnyWordSpec
+    with Inspectors
+    with Matchers
+    with ScalaFutures
+    with MockitoSugar
+    with DatastreamMetricsMock {
 
   trait Test {
     val mockLogger = mock[Logger]
@@ -44,17 +44,19 @@ class DatastreamHandlerUnitSpec
     val httpResult: HttpResult
 
     val datastreamHandler = new DatastreamHandler(
-      scheme   = "http",
-      host     = "localhost",
-      port     = 1234,
-      path     = "/some/path",
+      scheme = "http",
+      host = "localhost",
+      port = 1234,
+      path = "/some/path",
       wsClient = mock[WSClient],
-      metrics  = metrics
+      metrics = metrics
     ) {
       override val logger =
         mockLogger
 
-      override def sendHttpRequest(event: JsValue)(implicit ec: ExecutionContext): Future[HttpResult] =
+      override def sendHttpRequest(event: JsValue)(implicit
+          ec: ExecutionContext
+      ): Future[HttpResult] =
         Future.successful(httpResult)
     }
   }
@@ -65,7 +67,8 @@ class DatastreamHandlerUnitSpec
         new Test {
           override val httpResult = HttpResult.Response(code)
 
-          val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+          val result =
+            datastreamHandler.sendEvent(JsString("some event")).futureValue
 
           result shouldBe HandlerResult.Success
           verify(metrics.successCounter, times(1)).inc()
@@ -80,10 +83,13 @@ class DatastreamHandlerUnitSpec
         new Test {
           override val httpResult = HttpResult.Response(code)
 
-          val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+          val result =
+            datastreamHandler.sendEvent(JsString("some event")).futureValue
 
           result shouldBe HandlerResult.Rejected
-          verify(mockLogger).warn(s"AUDIT_REJECTED: received response with $code status code")
+          verify(mockLogger).warn(
+            s"AUDIT_REJECTED: received response with $code status code"
+          )
           verify(metrics.rejectCounter, times(1)).inc()
 
           verifyNoMoreInteractions(metrics.successCounter)
@@ -92,14 +98,19 @@ class DatastreamHandlerUnitSpec
       }
 
     "Return Failure + log error + increment counter for any response code of 3XX or 401-412 or 414-499 or 5XX" in
-      forAll(((300 to 399) ++ (401 to 412) ++ (414 to 499) ++ (500 to 599)).toList) { code =>
+      forAll(
+        ((300 to 399) ++ (401 to 412) ++ (414 to 499) ++ (500 to 599)).toList
+      ) { code =>
         new Test {
           override val httpResult = HttpResult.Response(code)
 
-          val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+          val result =
+            datastreamHandler.sendEvent(JsString("some event")).futureValue
 
           result shouldBe HandlerResult.Failure
-          verify(mockLogger).warn(s"AUDIT_FAILURE: received response with $code status code")
+          verify(mockLogger).warn(
+            s"AUDIT_FAILURE: received response with $code status code"
+          )
           verify(metrics.failureCounter, times(1)).inc()
 
           verifyNoMoreInteractions(metrics.successCounter)
@@ -110,7 +121,8 @@ class DatastreamHandlerUnitSpec
     "Return Failure + log error + increment counter for any malformed response" in new Test {
       override val httpResult = HttpResult.Malformed
 
-      val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+      val result =
+        datastreamHandler.sendEvent(JsString("some event")).futureValue
 
       result shouldBe HandlerResult.Failure
       verify(mockLogger).warn("AUDIT_FAILURE: received malformed response")
@@ -121,13 +133,18 @@ class DatastreamHandlerUnitSpec
     }
 
     "Return Failure + log error + increment counter for any failure response (if error is available)" in new Test {
-      val error = new Throwable("my error")
-      override val httpResult = HttpResult.Failure("my error message", Some(error))
+      val error               = new Throwable("my error")
+      override val httpResult =
+        HttpResult.Failure("my error message", Some(error))
 
-      val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+      val result =
+        datastreamHandler.sendEvent(JsString("some event")).futureValue
 
       result shouldBe HandlerResult.Failure
-      verify(mockLogger).warn("AUDIT_FAILURE: failed with error 'my error message'", error)
+      verify(mockLogger).warn(
+        "AUDIT_FAILURE: failed with error 'my error message'",
+        error
+      )
       verify(metrics.failureCounter, times(1)).inc()
 
       verifyNoMoreInteractions(metrics.successCounter)
@@ -137,10 +154,13 @@ class DatastreamHandlerUnitSpec
     "Return Failure + log error + increment counter for any failure response (if error is unavailable)" in new Test {
       override val httpResult = HttpResult.Failure("my error message")
 
-      val result = datastreamHandler.sendEvent(JsString("some event")).futureValue
+      val result =
+        datastreamHandler.sendEvent(JsString("some event")).futureValue
 
       result shouldBe HandlerResult.Failure
-      verify(mockLogger).warn("AUDIT_FAILURE: failed with error 'my error message'")
+      verify(mockLogger).warn(
+        "AUDIT_FAILURE: failed with error 'my error message'"
+      )
       verify(metrics.failureCounter, times(1)).inc()
 
       verifyNoMoreInteractions(metrics.successCounter)

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/DatastreamHandlerWireSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/DatastreamHandlerWireSpec.scala
@@ -34,35 +34,36 @@ import scala.concurrent.ExecutionContext
 import ExecutionContext.Implicits.global
 
 class DatastreamHandlerWireSpec
-  extends AnyWordSpec
-     with Inspectors
-     with Matchers
-     with BeforeAndAfterEach
-     with BeforeAndAfterAll
-     with ScalaFutures
-     with IntegrationPatience
-     with DatastreamMetricsMock {
+    extends AnyWordSpec
+    with Inspectors
+    with Matchers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with IntegrationPatience
+    with DatastreamMetricsMock {
 
   val datastreamTestPort: Int = WireMockUtils.availablePort()
-  val datastreamPath = "/write/audit"
+  val datastreamPath          = "/write/audit"
 
-  implicit val system   : ActorSystem          = ActorSystem()
-  implicit val lifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle()
+  implicit val system: ActorSystem             = ActorSystem()
+  implicit val lifecycle: ApplicationLifecycle =
+    new DefaultApplicationLifecycle()
 
   trait Test {
     val wsClient = WSClient(
       connectTimeout = 2000.millis,
       requestTimeout = 2000.millis,
-      userAgent      = "the-micro-service-name"
+      userAgent = "the-micro-service-name"
     )
 
     val datastreamHandler = new DatastreamHandler(
-      scheme         = "http",
-      host           = "localhost",
-      port           = datastreamTestPort,
-      path           = datastreamPath,
-      wsClient       = wsClient,
-      metrics        = mockDatastreamMetrics(Some("play.some-application"))
+      scheme = "http",
+      host = "localhost",
+      port = datastreamTestPort,
+      path = datastreamPath,
+      wsClient = wsClient,
+      metrics = mockDatastreamMetrics(Some("play.some-application"))
     )
   }
 
@@ -88,7 +89,11 @@ class DatastreamHandlerWireSpec
       val event = JsString("EVENT")
       stub(event, 204)
       datastreamHandler.sendEvent(event).futureValue
-      WireMock.verify(1, postRequestedFor(urlPathEqualTo(datastreamPath)).withHeader("User-Agent", equalTo("the-micro-service-name")))
+      WireMock.verify(
+        1,
+        postRequestedFor(urlPathEqualTo(datastreamPath))
+          .withHeader("User-Agent", equalTo("the-micro-service-name"))
+      )
     }
   }
 
@@ -106,7 +111,8 @@ class DatastreamHandlerWireSpec
       WireMock.stubFor(
         post(urlPathEqualTo(datastreamPath))
           .withRequestBody(WireMock.equalTo(event.toString))
-          .willReturn(aResponse().withFixedDelay(3000).withStatus(204)))
+          .willReturn(aResponse().withFixedDelay(3000).withStatus(204))
+      )
 
       whenReady(datastreamHandler.sendEvent(event), timeout(4000.millis)) { result =>
         WireMock.verify(1, postRequestedFor(urlPathEqualTo(datastreamPath)))
@@ -116,19 +122,27 @@ class DatastreamHandlerWireSpec
 
     "return a failure if the WSClient is in IllegalStateException: Closed state " in new Test {
       wsClient.close()
-      datastreamHandler.sendEvent(JsString("CLOSED")).futureValue shouldBe HandlerResult.Failure
+      datastreamHandler
+        .sendEvent(JsString("CLOSED"))
+        .futureValue shouldBe HandlerResult.Failure
     }
   }
 
   "Calls to Datastream that return an empty response" should {
     "not retry the POST (beyond default lib retries) and return a failure" in {
-      verifyOnlyDefaultLibraryRetries(JsString("EMPTY_RESPONSE"), Fault.EMPTY_RESPONSE)
+      verifyOnlyDefaultLibraryRetries(
+        JsString("EMPTY_RESPONSE"),
+        Fault.EMPTY_RESPONSE
+      )
     }
   }
 
   "Calls to Datastream that return a bad response" should {
     "not retry the POST (beyond default lib retries) and return a failure" in {
-      verifyOnlyDefaultLibraryRetries(JsString("RANDOM_DATA_THEN_CLOSE"), Fault.RANDOM_DATA_THEN_CLOSE)
+      verifyOnlyDefaultLibraryRetries(
+        JsString("RANDOM_DATA_THEN_CLOSE"),
+        Fault.RANDOM_DATA_THEN_CLOSE
+      )
     }
   }
 
@@ -146,7 +160,10 @@ class DatastreamHandlerWireSpec
         .willReturn(aResponse().withFault(fault))
     )
 
-  private def verifyOnlyDefaultLibraryRetries(event: JsValue, fault: Fault): Unit = new Test {
+  private def verifyOnlyDefaultLibraryRetries(
+      event: JsValue,
+      fault: Fault
+  ): Unit = new Test {
     stub(event, fault)
     val result = datastreamHandler.sendEvent(event).futureValue
 
@@ -156,7 +173,11 @@ class DatastreamHandlerWireSpec
     WireMock.verify(6, postRequestedFor(urlPathEqualTo(datastreamPath)))
   }
 
-  private def verifySingleCall(event: JsValue, responseStatus: Integer, expectedResult: HandlerResult): Unit = new Test {
+  private def verifySingleCall(
+      event: JsValue,
+      responseStatus: Integer,
+      expectedResult: HandlerResult
+  ): Unit = new Test {
     stub(event, responseStatus)
 
     val result = datastreamHandler.sendEvent(event).futureValue

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/HttpHandlerSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/HttpHandlerSpec.scala
@@ -33,15 +33,10 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class HttpHandlerSpec
-  extends AnyWordSpec
-     with Inspectors
-     with Matchers
-     with ScalaFutures
-     with MockitoSugar {
+class HttpHandlerSpec extends AnyWordSpec with Inspectors with Matchers with ScalaFutures with MockitoSugar {
 
   trait Test {
-    val wsClient = mock[WSClient]
+    val wsClient    = mock[WSClient]
     val httpHandler = new HttpHandler(
       endpointUrl = new URL("http", "localhost", 9999, "/some/path"),
       wsClient = wsClient
@@ -62,29 +57,51 @@ class HttpHandlerSpec
     )
 
     "return failure whenever WSClient url throws" in new Test {
-      val e = new IllegalArgumentException("illegal argument") // only permitted error via checked exception
+      val e = new IllegalArgumentException(
+        "illegal argument"
+      ) // only permitted error via checked exception
       when(wsClient.url(any[String])).thenThrow(e)
 
-      httpHandler.sendHttpRequest(JsString("any old thing")).futureValue shouldBe HttpResult.Failure("Error opening connection or sending request (sync)", Some(e))
+      httpHandler
+        .sendHttpRequest(JsString("any old thing"))
+        .futureValue shouldBe HttpResult.Failure(
+        "Error opening connection or sending request (sync)",
+        Some(e)
+      )
     }
 
-    "return failure whenever WSClient POST throws" in forAll(checkedPostExceptions) { e =>
+    "return failure whenever WSClient POST throws" in forAll(
+      checkedPostExceptions
+    ) { e =>
       new Test {
         val requestMock = mock[StandaloneWSRequest]
         when(wsClient.url(any[String])).thenReturn(requestMock)
         when(requestMock.post(any)(any[BodyWritable[_]])).thenThrow(e)
 
-        httpHandler.sendHttpRequest(JsString("any old thing")).futureValue shouldBe HttpResult.Failure("Error opening connection or sending request (sync)", Some(e))
+        httpHandler
+          .sendHttpRequest(JsString("any old thing"))
+          .futureValue shouldBe HttpResult.Failure(
+          "Error opening connection or sending request (sync)",
+          Some(e)
+        )
       }
     }
 
-    "return failure whenever WSClient POST returns failed future" in forAll(checkedPostExceptions ++ uncheckedPostExceptions) { e =>
+    "return failure whenever WSClient POST returns failed future" in forAll(
+      checkedPostExceptions ++ uncheckedPostExceptions
+    ) { e =>
       new Test {
         val requestMock = mock[StandaloneWSRequest]
         when(wsClient.url(any[String])).thenReturn(requestMock)
-        when(requestMock.post(any)(any[BodyWritable[_]])).thenReturn(Future.failed(e))
+        when(requestMock.post(any)(any[BodyWritable[_]]))
+          .thenReturn(Future.failed(e))
 
-        httpHandler.sendHttpRequest(JsString("any old thing")).futureValue shouldBe HttpResult.Failure("Error opening connection or sending request (async)", Some(e))
+        httpHandler
+          .sendHttpRequest(JsString("any old thing"))
+          .futureValue shouldBe HttpResult.Failure(
+          "Error opening connection or sending request (async)",
+          Some(e)
+        )
       }
     }
   }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/LoggingHandlerSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/handler/LoggingHandlerSpec.scala
@@ -27,11 +27,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class LoggingHandlerSpec extends AnyWordSpec with MockitoSugar {
 
   val mockLog: Logger = mock[Logger]
-  val loggingHandler = new LoggingHandler(mockLog)
+  val loggingHandler  = new LoggingHandler(mockLog)
 
   "LoggingHandler" should {
     "log the event" in {
-      val expectedLogContent = """DS_EventMissed_AuditRequestFailure : audit item : "FAILED_EVENT""""
+      val expectedLogContent =
+        """DS_EventMissed_AuditRequestFailure : audit item : "FAILED_EVENT""""
 
       loggingHandler.sendEvent(JsString("FAILED_EVENT"))
 

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiserSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/audit/serialiser/AuditSerialiserSpec.scala
@@ -21,7 +21,14 @@ import play.api.libs.json.{JsString, Json}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.audit.BuildInfo
-import uk.gov.hmrc.play.audit.model.{DataCall, DataEvent, ExtendedDataEvent, MergedDataEvent, RedactionLog, TruncationLog}
+import uk.gov.hmrc.play.audit.model.{
+  DataCall,
+  DataEvent,
+  ExtendedDataEvent,
+  MergedDataEvent,
+  RedactionLog,
+  TruncationLog
+}
 
 class AuditSerialiserSpec extends AnyWordSpec with Matchers {
 
@@ -40,11 +47,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
 
     "serialise DataEvent with truncationLog & redactions" in {
       testDataEvent(
-        truncationLog =
-          TruncationLog.Entry(
-            truncatedFields = List("request.detail.requestdetailkey"),
-            timestamp       = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        truncationLog = TruncationLog.Entry(
+          truncatedFields = List("request.detail.requestdetailkey"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedTruncationJson = s""",
           "truncation": {
             "truncationLog": [{
@@ -54,11 +60,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "version"        : "${BuildInfo.version}"
             }]
           }""",
-        redactionLog =
-          RedactionLog.Entry(
-            redactedFields = List("request.detail.requestBody"),
-            timestamp      = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        redactionLog = RedactionLog.Entry(
+          redactedFields = List("request.detail.requestBody"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedRedactionJson = s"""
           "redaction": {
             "containsRedactions": true,
@@ -68,25 +73,27 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "code"          : "play-auditing",
               "version"       : "${BuildInfo.version}"
             }]
-          }""",
+          }"""
       )
     }
     def testDataEvent(
-      truncationLog: TruncationLog,
-      expectedTruncationJson: String,
-      redactionLog: RedactionLog,
-      expectedRedactionJson: String
+        truncationLog: TruncationLog,
+        expectedTruncationJson: String,
+        redactionLog: RedactionLog,
+        expectedRedactionJson: String
     ) =
-      AuditSerialiser.serialise(DataEvent(
-        auditSource   = "myapp",
-        auditType     = "RequestReceived",
-        eventId       = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
-        tags          = Map("tagkey" -> "tagval"),
-        detail        = Map("detailkey" -> "detailval"),
-        generatedAt   = Instant.parse("2007-12-03T10:15:30.000Z"),
-        truncationLog = truncationLog,
-        redactionLog  = redactionLog
-      )) shouldBe Json.parse(s"""{
+      AuditSerialiser.serialise(
+        DataEvent(
+          auditSource = "myapp",
+          auditType = "RequestReceived",
+          eventId = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
+          tags = Map("tagkey" -> "tagval"),
+          detail = Map("detailkey" -> "detailval"),
+          generatedAt = Instant.parse("2007-12-03T10:15:30.000Z"),
+          truncationLog = truncationLog,
+          redactionLog = redactionLog
+        )
+      ) shouldBe Json.parse(s"""{
         "auditSource" : "myapp",
         "auditType"   : "RequestReceived",
         "eventId"     : "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
@@ -113,11 +120,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
 
     "serialise ExtendedDataEvent with truncationLog & redactions" in {
       testExtendedDataEvent(
-        truncationLog =
-          TruncationLog.Entry(
-            truncatedFields = List("request.detail.requestdetailkey"),
-            timestamp       = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        truncationLog = TruncationLog.Entry(
+          truncatedFields = List("request.detail.requestdetailkey"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedTruncationJson = s""",
           "truncation": {
             "truncationLog": [{
@@ -127,11 +133,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "version"        : "${BuildInfo.version}"
             }]
           }""",
-        redactionLog =
-          RedactionLog.Entry(
-            redactedFields = List("request.detail.requestBody"),
-            timestamp      = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        redactionLog = RedactionLog.Entry(
+          redactedFields = List("request.detail.requestBody"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedRedactionJson = s"""
           "redaction": {
             "containsRedactions": true,
@@ -141,26 +146,28 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "code"          : "play-auditing",
               "version"       : "${BuildInfo.version}"
             }]
-          }""",
+          }"""
       )
     }
 
     def testExtendedDataEvent(
-      truncationLog: TruncationLog,
-      expectedTruncationJson: String,
-      redactionLog: RedactionLog,
-      expectedRedactionJson: String
+        truncationLog: TruncationLog,
+        expectedTruncationJson: String,
+        redactionLog: RedactionLog,
+        expectedRedactionJson: String
     ) =
-      AuditSerialiser.serialise(ExtendedDataEvent(
-        auditSource   = "myapp",
-        auditType     = "RequestReceived",
-        eventId       = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
-        tags          = Map("tagkey" -> "tagval"),
-        detail        = JsString("detail"),
-        generatedAt   = Instant.parse("2007-12-03T10:15:30.000Z"),
-        truncationLog = truncationLog,
-        redactionLog  = redactionLog
-      )) shouldBe Json.parse(s"""{
+      AuditSerialiser.serialise(
+        ExtendedDataEvent(
+          auditSource = "myapp",
+          auditType = "RequestReceived",
+          eventId = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
+          tags = Map("tagkey" -> "tagval"),
+          detail = JsString("detail"),
+          generatedAt = Instant.parse("2007-12-03T10:15:30.000Z"),
+          truncationLog = truncationLog,
+          redactionLog = redactionLog
+        )
+      ) shouldBe Json.parse(s"""{
         "auditSource" : "myapp",
         "auditType"   : "RequestReceived",
         "eventId"     : "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
@@ -187,11 +194,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
 
     "serialise MergedDataEvent with truncationLog" in {
       testMergedDataEvent(
-        truncationLog =
-          TruncationLog.Entry(
-            truncatedFields = List("request.detail.requestdetailkey"),
-            timestamp       = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        truncationLog = TruncationLog.Entry(
+          truncatedFields = List("request.detail.requestdetailkey"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedTruncationJson = s""",
           "truncation": {
             "truncationLog": [{
@@ -201,11 +207,10 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "version"        : "${BuildInfo.version}"
             }]
           }""",
-        redactionLog =
-          RedactionLog.Entry(
-            redactedFields = List("request.detail.requestBody"),
-            timestamp      = Instant.parse("2007-12-03T10:16:31.124Z")
-          ),
+        redactionLog = RedactionLog.Entry(
+          redactedFields = List("request.detail.requestBody"),
+          timestamp = Instant.parse("2007-12-03T10:16:31.124Z")
+        ),
         expectedRedactionJson = s"""
           "redaction": {
             "containsRedactions": true,
@@ -215,33 +220,35 @@ class AuditSerialiserSpec extends AnyWordSpec with Matchers {
               "code"          : "play-auditing",
               "version"       : "${BuildInfo.version}"
             }]
-          }""",
+          }"""
       )
     }
 
     def testMergedDataEvent(
-      truncationLog: TruncationLog,
-      expectedTruncationJson: String,
-      redactionLog: RedactionLog,
-      expectedRedactionJson: String
+        truncationLog: TruncationLog,
+        expectedTruncationJson: String,
+        redactionLog: RedactionLog,
+        expectedRedactionJson: String
     ) =
-      AuditSerialiser.serialise(MergedDataEvent(
-        auditSource   = "myapp",
-        auditType     = "RequestReceived",
-        eventId       = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
-        request       = DataCall(
-                          tags   = Map("requesttagkey" -> "requesttagval"),
-                          detail = Map("requestdetailkey" -> "requestdetailval"),
-                          generatedAt = Instant.parse("2007-12-03T10:15:30.123Z")
-                        ),
-        response      = DataCall(
-                          tags   = Map("responsetagkey" -> "responsetagval"),
-                          detail = Map("responsedetailkey" -> "responsedetailval"),
-                          generatedAt = Instant.parse("2007-12-03T10:16:31.123Z")
-                        ),
-        truncationLog = truncationLog,
-        redactionLog  = redactionLog
-      )) shouldBe Json.parse(s"""{
+      AuditSerialiser.serialise(
+        MergedDataEvent(
+          auditSource = "myapp",
+          auditType = "RequestReceived",
+          eventId = "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",
+          request = DataCall(
+            tags = Map("requesttagkey" -> "requesttagval"),
+            detail = Map("requestdetailkey" -> "requestdetailval"),
+            generatedAt = Instant.parse("2007-12-03T10:15:30.123Z")
+          ),
+          response = DataCall(
+            tags = Map("responsetagkey" -> "responsetagval"),
+            detail = Map("responsedetailkey" -> "responsedetailval"),
+            generatedAt = Instant.parse("2007-12-03T10:16:31.123Z")
+          ),
+          truncationLog = truncationLog,
+          redactionLog = redactionLog
+        )
+      ) shouldBe Json.parse(s"""{
         "auditSource" : "myapp",
         "auditType"   : "RequestReceived",
         "eventId"     : "cb5ebe82-cf3c-4f15-bd92-39a6baa1f929",

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/HeaderFieldsExtractorTestSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/HeaderFieldsExtractorTestSpec.scala
@@ -19,19 +19,23 @@ package uk.gov.hmrc.play.audit.http
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class HeaderFieldsExtractorTestSpec
-  extends AnyWordSpec
-  with Matchers {
+class HeaderFieldsExtractorTestSpec extends AnyWordSpec with Matchers {
 
   "The optional audit fields code" should {
     "Return only surrogate header" in {
       val optionalFields =
-        HeaderFieldsExtractor.optionalAuditFieldsSeq(Map("Foo" -> "Bar", "Ehh" -> "Meh", "Surrogate" -> "Cool").view.mapValues(Seq(_)).toMap)
+        HeaderFieldsExtractor.optionalAuditFieldsSeq(
+          Map("Foo" -> "Bar", "Ehh" -> "Meh", "Surrogate" -> "Cool").view
+            .mapValues(Seq(_))
+            .toMap
+        )
       optionalFields shouldBe Map("surrogate" -> "Cool")
     }
 
     "Return no surrogate headers when none in headers" in {
-      val optionalFields = HeaderFieldsExtractor.optionalAuditFieldsSeq(Map("Foo" -> "Bar", "Ehh" -> "Meh").view.mapValues(Seq(_)).toMap)
+      val optionalFields = HeaderFieldsExtractor.optionalAuditFieldsSeq(
+        Map("Foo" -> "Bar", "Ehh" -> "Meh").view.mapValues(Seq(_)).toMap
+      )
       optionalFields shouldBe empty
     }
   }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
@@ -42,13 +42,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class HttpAuditingSpec
-  extends AnyWordSpec
-     with Matchers
-     with Inspectors
-     with Eventually
-     with MockitoSugar
-     with ScalaFutures
-     with IntegrationPatience {
+    extends AnyWordSpec
+    with Matchers
+    with Inspectors
+    with Eventually
+    with MockitoSugar
+    with ScalaFutures
+    with IntegrationPatience {
 
   private val outboundCallAuditType: String = "OutboundCall"
   private val requestDateTime: Instant      = Instant.now
@@ -57,7 +57,7 @@ class HttpAuditingSpec
   private val getVerb                       = "GET"
 
   "HttpAuditing.auditRequestWithResponseF" should {
-    val deviceID = "A_DEVICE_ID"
+    val deviceID   = "A_DEVICE_ID"
     val serviceUri = "https://www.google.co.uk"
 
     "handle the happy path with a valid audit event passing through" in {
@@ -69,11 +69,13 @@ class HttpAuditingSpec
       val requestBody  = None
       val responseBody = "the response body"
       val statusCode   = 200
-      val responseF    = Future.successful(ResponseData(
-                           body    = Data.pure(responseBody),
-                           status  = statusCode,
-                           headers = Map.empty
-                         ))
+      val responseF    = Future.successful(
+        ResponseData(
+          body = Data.pure(responseBody),
+          status = statusCode,
+          headers = Map.empty
+        )
+      )
 
       whenAuditSuccess(connector)
 
@@ -86,95 +88,12 @@ class HttpAuditingSpec
       )
       val request = RequestData(headers = sentHeaders, body = requestBody)
 
-      httpWithAudit.auditRequestWithResponseF(getVerb, serviceUri, request, responseF)(hc)
-
-      eventually(timeout(Span(1, Seconds))) {
-        val dataEvent = verifyAndRetrieveEvent(connector)
-
-        dataEvent.auditSource shouldBe httpWithAudit.appName
-        dataEvent.auditType   shouldBe outboundCallAuditType
-
-        dataEvent.request.tags shouldBe Map(
-          xSessionId          -> "-",
-          xRequestId          -> "-",
-          Path                -> serviceUri,
-          "clientIP"          -> "-",
-          "clientPort"        -> "-",
-          "Akamai-Reputation" -> "-",
-          HeaderNames.deviceID -> deviceID
-        )
-        dataEvent.request.detail shouldBe Map(
-          "ipAddress"          -> "-",
-          Path                 -> serviceUri,
-          Method               -> getVerb,
-          "surrogate"          -> "true",
-          "allowlist-header"   -> "test-value"
-        )
-        dataEvent.request.generatedAt shouldBe requestDateTime
-
-        dataEvent.response.tags   shouldBe empty
-        dataEvent.response.detail shouldBe Map(
-          ResponseMessage -> responseBody,
-          StatusCode      -> statusCode.toString
-        )
-        dataEvent.response.generatedAt shouldBe responseDateTime
-      }
-    }
-
-    "not audit extra headers by default" in {
-      val connector = mock[AuditConnector]
-      when(connector.isEnabled).thenReturn(true)
-      when(connector.auditSentHeaders).thenReturn(false)
-      val httpWithAudit = new HttpWithAuditing(connector)
-
-      val requestBody  = None
-      val responseBody = "the response body"
-      val statusCode   = 200
-      val responseF    = Future.successful(ResponseData(
-                           body    = Data.pure(responseBody),
-                           status  = statusCode,
-                           headers = Map.empty
-                         ))
-
-      whenAuditSuccess(connector)
-
-      val hc = HeaderCarrier(deviceID = Some(deviceID))
-
-      val sentHeaders = Seq(
-        surrogate      -> "true",
-        "extra-header" -> "test-value"
-      )
-      val request = RequestData(
-        headers = sentHeaders,
-        body    = requestBody
-      )
-
-      httpWithAudit.auditRequestWithResponseF(getVerb, serviceUri, request, responseF)(hc)
-
-      eventually(timeout(Span(1, Seconds))) {
-        val dataEvent = verifyAndRetrieveEvent(connector)
-        dataEvent.request.detail shouldNot contain key "extra-header"
-       }
-    }
-
-    "still send an audit message if the future fails when evaluating the response" in {
-      val hc            = HeaderCarrier(deviceID = Some(deviceID))
-      val connector     = mock[AuditConnector]
-      when(connector.isEnabled).thenReturn(true)
-      val httpWithAudit = new HttpWithAuditing(connector)
-
-      val requestBody  = "the infamous request body"
-      val errorMessage = "FOO bar"
-      val responseF    = Future.failed(new Exception(errorMessage))
-
-      whenAuditSuccess(connector)
-
-      val request = RequestData(
-        headers = Seq.empty,
-        body    = Some(Data.pure(HookData.FromString(requestBody)))
-      )
-
-      httpWithAudit.auditRequestWithResponseF(postVerb, serviceUri, request, responseF)(hc)
+      httpWithAudit.auditRequestWithResponseF(
+        getVerb,
+        serviceUri,
+        request,
+        responseF
+      )(hc)
 
       eventually(timeout(Span(1, Seconds))) {
         val dataEvent = verifyAndRetrieveEvent(connector)
@@ -194,13 +113,115 @@ class HttpAuditingSpec
         dataEvent.request.detail shouldBe Map(
           "ipAddress"        -> "-",
           Path               -> serviceUri,
-          Method             -> postVerb,
-          RequestBody        -> requestBody
+          Method             -> getVerb,
+          "surrogate"        -> "true",
+          "allowlist-header" -> "test-value"
         )
         dataEvent.request.generatedAt shouldBe requestDateTime
 
-        dataEvent.response.tags        shouldBe empty
-        dataEvent.response.detail      should contain(FailedRequestMessage -> errorMessage)
+        dataEvent.response.tags shouldBe empty
+        dataEvent.response.detail shouldBe Map(
+          ResponseMessage -> responseBody,
+          StatusCode      -> statusCode.toString
+        )
+        dataEvent.response.generatedAt shouldBe responseDateTime
+      }
+    }
+
+    "not audit extra headers by default" in {
+      val connector = mock[AuditConnector]
+      when(connector.isEnabled).thenReturn(true)
+      when(connector.auditSentHeaders).thenReturn(false)
+      val httpWithAudit = new HttpWithAuditing(connector)
+
+      val requestBody  = None
+      val responseBody = "the response body"
+      val statusCode   = 200
+      val responseF    = Future.successful(
+        ResponseData(
+          body = Data.pure(responseBody),
+          status = statusCode,
+          headers = Map.empty
+        )
+      )
+
+      whenAuditSuccess(connector)
+
+      val hc = HeaderCarrier(deviceID = Some(deviceID))
+
+      val sentHeaders = Seq(
+        surrogate      -> "true",
+        "extra-header" -> "test-value"
+      )
+      val request = RequestData(
+        headers = sentHeaders,
+        body = requestBody
+      )
+
+      httpWithAudit.auditRequestWithResponseF(
+        getVerb,
+        serviceUri,
+        request,
+        responseF
+      )(hc)
+
+      eventually(timeout(Span(1, Seconds))) {
+        val dataEvent = verifyAndRetrieveEvent(connector)
+        dataEvent.request.detail shouldNot contain key "extra-header"
+      }
+    }
+
+    "still send an audit message if the future fails when evaluating the response" in {
+      val hc        = HeaderCarrier(deviceID = Some(deviceID))
+      val connector = mock[AuditConnector]
+      when(connector.isEnabled).thenReturn(true)
+      val httpWithAudit = new HttpWithAuditing(connector)
+
+      val requestBody  = "the infamous request body"
+      val errorMessage = "FOO bar"
+      val responseF    = Future.failed(new Exception(errorMessage))
+
+      whenAuditSuccess(connector)
+
+      val request = RequestData(
+        headers = Seq.empty,
+        body = Some(Data.pure(HookData.FromString(requestBody)))
+      )
+
+      httpWithAudit.auditRequestWithResponseF(
+        postVerb,
+        serviceUri,
+        request,
+        responseF
+      )(hc)
+
+      eventually(timeout(Span(1, Seconds))) {
+        val dataEvent = verifyAndRetrieveEvent(connector)
+
+        dataEvent.auditSource shouldBe httpWithAudit.appName
+        dataEvent.auditType shouldBe outboundCallAuditType
+
+        dataEvent.request.tags shouldBe Map(
+          xSessionId           -> "-",
+          xRequestId           -> "-",
+          Path                 -> serviceUri,
+          "clientIP"           -> "-",
+          "clientPort"         -> "-",
+          "Akamai-Reputation"  -> "-",
+          HeaderNames.deviceID -> deviceID
+        )
+        dataEvent.request.detail shouldBe Map(
+          "ipAddress" -> "-",
+          Path        -> serviceUri,
+          Method      -> postVerb,
+          RequestBody -> requestBody
+        )
+        dataEvent.request.generatedAt shouldBe requestDateTime
+
+        dataEvent.response.tags shouldBe empty
+        dataEvent.response.detail should contain(
+          FailedRequestMessage -> errorMessage
+        )
         dataEvent.response.generatedAt shouldBe responseDateTime
       }
     }
@@ -216,10 +237,15 @@ class HttpAuditingSpec
 
       val request = RequestData(
         headers = Seq.empty,
-        body    = Some(Data.pure(HookData.FromString(requestBody)))
+        body = Some(Data.pure(HookData.FromString(requestBody)))
       )
 
-      when(connector.sendMergedEvent(any[MergedDataEvent])(any[HeaderCarrier], any[ExecutionContext]))
+      when(
+        connector.sendMergedEvent(any[MergedDataEvent])(
+          any[HeaderCarrier],
+          any[ExecutionContext]
+        )
+      )
         .thenReturn(Future.successful(AuditResult.Failure("any failure")))
 
       when(connector.isEnabled)
@@ -228,10 +254,18 @@ class HttpAuditingSpec
       when(connector.auditSentHeaders)
         .thenReturn(false)
 
-      httpWithAudit.auditRequestWithResponseF(postVerb, serviceUri, request, responseF)(hc)
+      httpWithAudit.auditRequestWithResponseF(
+        postVerb,
+        serviceUri,
+        request,
+        responseF
+      )(hc)
 
       eventually(timeout(Span(1, Seconds))) {
-        verify(connector, times(1)).sendMergedEvent(any[MergedDataEvent])(any[HeaderCarrier], any[ExecutionContext])
+        verify(connector, times(1)).sendMergedEvent(any[MergedDataEvent])(
+          any[HeaderCarrier],
+          any[ExecutionContext]
+        )
         verify(connector).isEnabled
         verify(connector).auditSentHeaders
         verifyNoMoreInteractions(connector)
@@ -249,11 +283,18 @@ class HttpAuditingSpec
 
       val request = RequestData(
         headers = Seq.empty,
-        body    = Some(Data.pure(HookData.FromString(requestBody)))
+        body = Some(Data.pure(HookData.FromString(requestBody)))
       )
 
-      when(connector.sendMergedEvent(any[MergedDataEvent])(any[HeaderCarrier], any[ExecutionContext]))
-        .thenReturn(Future.failed(new IllegalArgumentException("any exception")))
+      when(
+        connector.sendMergedEvent(any[MergedDataEvent])(
+          any[HeaderCarrier],
+          any[ExecutionContext]
+        )
+      )
+        .thenReturn(
+          Future.failed(new IllegalArgumentException("any exception"))
+        )
 
       when(connector.isEnabled)
         .thenReturn(true)
@@ -261,10 +302,18 @@ class HttpAuditingSpec
       when(connector.auditSentHeaders)
         .thenReturn(false)
 
-      httpWithAudit.auditRequestWithResponseF(postVerb, serviceUri, request, responseF)(hc)
+      httpWithAudit.auditRequestWithResponseF(
+        postVerb,
+        serviceUri,
+        request,
+        responseF
+      )(hc)
 
       eventually(timeout(Span(1, Seconds))) {
-        verify(connector, times(1)).sendMergedEvent(any[MergedDataEvent])(any[HeaderCarrier], any[ExecutionContext])
+        verify(connector, times(1)).sendMergedEvent(any[MergedDataEvent])(
+          any[HeaderCarrier],
+          any[ExecutionContext]
+        )
         verify(connector).isEnabled
         verify(connector).auditSentHeaders
         verifyNoMoreInteractions(connector)
@@ -274,26 +323,31 @@ class HttpAuditingSpec
 
   "Calling audit" should {
     val serviceUri = "http://localhost/service/path"
-    val deviceID = "A_DEVICE_ID"
+    val deviceID   = "A_DEVICE_ID"
 
     implicit val hc: HeaderCarrier = HeaderCarrier(deviceID = Some(deviceID))
 
     "send unique event of type OutboundCall" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
-      val requestBody  = None
-      val request      = httpWithAudit.buildRequest(getVerb, serviceUri, Seq(surrogate -> "true"), requestBody)
+      val requestBody = None
+      val request     = httpWithAudit.buildRequest(
+        getVerb,
+        serviceUri,
+        Seq(surrogate -> "true"),
+        requestBody
+      )
       val responseBody = "the response body"
       val response     = ResponseData(
-                           body    = Data.pure(responseBody),
-                           status  = 200,
-                           headers = Map.empty
-                         )
+        body = Data.pure(responseBody),
+        status = 200,
+        headers = Map.empty
+      )
 
       implicit val hc: HeaderCarrier = HeaderCarrier(
-        deviceID       = Some(deviceID),
-        trueClientIp   = Some("192.168.1.2"),
+        deviceID = Some(deviceID),
+        trueClientIp = Some("192.168.1.2"),
         trueClientPort = Some("12000")
       )
 
@@ -304,7 +358,7 @@ class HttpAuditingSpec
       val dataEvent = verifyAndRetrieveEvent(connector)
 
       dataEvent.auditSource shouldBe httpWithAudit.appName
-      dataEvent.auditType   shouldBe outboundCallAuditType
+      dataEvent.auditType shouldBe outboundCallAuditType
 
       dataEvent.request.tags shouldBe Map(
         xSessionId           -> "-",
@@ -316,14 +370,14 @@ class HttpAuditingSpec
         HeaderNames.deviceID -> deviceID
       )
       dataEvent.request.detail shouldBe Map(
-        "ipAddress"   -> "-",
-        Path          -> serviceUri,
-        Method        -> getVerb,
-        "surrogate"   -> "true"
+        "ipAddress" -> "-",
+        Path        -> serviceUri,
+        Method      -> getVerb,
+        "surrogate" -> "true"
       )
       dataEvent.request.generatedAt shouldBe requestDateTime
 
-      dataEvent.response.tags   shouldBe empty
+      dataEvent.response.tags shouldBe empty
       dataEvent.response.detail shouldBe Map(
         ResponseMessage -> responseBody,
         StatusCode      -> response.status.toString
@@ -337,12 +391,17 @@ class HttpAuditingSpec
       val requestBody   = "The request body gets added to the audit details"
       val responseBody  = "the response body"
       val response      = ResponseData(
-                             body    = Data.pure(responseBody),
-                             status  = 200,
-                             headers = Map.empty
-                           )
+        body = Data.pure(responseBody),
+        status = 200,
+        headers = Map.empty
+      )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -354,26 +413,26 @@ class HttpAuditingSpec
       dataEvent.auditType shouldBe outboundCallAuditType
 
       dataEvent.request.tags shouldBe Map(
-        xSessionId            -> "-",
-        xRequestId            -> "-",
-        Path                  -> serviceUri,
-        "clientIP"            -> "-",
-        "clientPort"          -> "-",
-        "Akamai-Reputation"   -> "-",
-         HeaderNames.deviceID -> deviceID
+        xSessionId           -> "-",
+        xRequestId           -> "-",
+        Path                 -> serviceUri,
+        "clientIP"           -> "-",
+        "clientPort"         -> "-",
+        "Akamai-Reputation"  -> "-",
+        HeaderNames.deviceID -> deviceID
       )
       dataEvent.request.detail shouldBe Map(
-        "ipAddress"        -> "-",
-        Path               -> serviceUri,
-        Method             -> postVerb,
-        RequestBody        -> requestBody
+        "ipAddress" -> "-",
+        Path        -> serviceUri,
+        Method      -> postVerb,
+        RequestBody -> requestBody
       )
       dataEvent.request.generatedAt shouldBe requestDateTime
 
       dataEvent.response.tags shouldBe empty
       dataEvent.response.detail shouldBe Map(
-        ResponseMessage     -> responseBody,
-        StatusCode          -> response.status.toString
+        ResponseMessage -> responseBody,
+        StatusCode      -> response.status.toString
       )
       dataEvent.response.generatedAt shouldBe responseDateTime
 
@@ -391,13 +450,18 @@ class HttpAuditingSpec
       )
 
       val responseBody = Json.obj("password" -> "hide-me").toString
-      val response = ResponseData(
-        body    = Data.pure(responseBody),
-        status  = 200,
+      val response     = ResponseData(
+        body = Data.pure(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromMap(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromMap(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -405,27 +469,45 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      dataEvent.request.detail(RequestBody) shouldBe requestBody.toString.replace("List(hide-me)", "########")
-      dataEvent.response.detail(ResponseMessage) shouldBe responseBody.replace("hide-me", "########")
+      dataEvent.request.detail(RequestBody) shouldBe requestBody.toString
+        .replace("List(hide-me)", "########")
+      dataEvent.response.detail(ResponseMessage) shouldBe responseBody.replace(
+        "hide-me",
+        "########"
+      )
 
-      dataEvent.redactionLog.redactedFields shouldBe List("request.detail.requestBody", "response.detail.responseMessage")
+      dataEvent.redactionLog.redactedFields shouldBe List(
+        "request.detail.requestBody",
+        "response.detail.responseMessage"
+      )
     }
 
     "mask passwords in an OutboundCall using json" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
-      val sampleJson = Json.obj("a" -> Json.arr(Json.obj("ok" -> 1, "password" -> "hide-me", "PASSWD" -> "hide-me"))).toString
-      val requestBody = sampleJson
+      val sampleJson = Json
+        .obj(
+          "a" -> Json.arr(
+            Json.obj("ok" -> 1, "password" -> "hide-me", "PASSWD" -> "hide-me")
+          )
+        )
+        .toString
+      val requestBody  = sampleJson
       val responseBody = sampleJson
 
       val response = ResponseData(
-        body    = Data.pure(responseBody),
-        status  = 200,
+        body = Data.pure(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -433,14 +515,20 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      Json.parse(dataEvent.request.detail(RequestBody)) shouldBe Json.parse(requestBody.replace("hide-me", "########"))
-      Json.parse(dataEvent.response.detail(ResponseMessage)) shouldBe Json.parse(responseBody.replace("hide-me", "########"))
+      Json.parse(dataEvent.request.detail(RequestBody)) shouldBe Json.parse(
+        requestBody.replace("hide-me", "########")
+      )
+      Json.parse(dataEvent.response.detail(ResponseMessage)) shouldBe Json
+        .parse(responseBody.replace("hide-me", "########"))
 
-      dataEvent.redactionLog.redactedFields shouldBe List("request.detail.requestBody", "response.detail.responseMessage")
+      dataEvent.redactionLog.redactedFields shouldBe List(
+        "request.detail.requestBody",
+        "response.detail.responseMessage"
+      )
     }
 
     "mask passwords in an OutboundCall using xml" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val sampleXml =
@@ -452,15 +540,20 @@ class HttpAuditingSpec
           |    <bar PassWord="hide-me" prefix:PASSWORD="hide-me"/>
           |</abc>""".stripMargin
 
-      val requestBody = sampleXml
+      val requestBody  = sampleXml
       val responseBody = sampleXml
-      val response = ResponseData(
-                           body    = Data.pure(responseBody),
-                           status  = 200,
-                           headers = Map.empty
-                         )
+      val response     = ResponseData(
+        body = Data.pure(responseBody),
+        status = 200,
+        headers = Map.empty
+      )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -468,26 +561,42 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      scala.xml.XML.loadString(dataEvent.request.detail(RequestBody))      shouldBe scala.xml.XML.loadString(requestBody.replace("hide-me", "########"))
-      scala.xml.XML.loadString(dataEvent.response.detail(ResponseMessage)) shouldBe scala.xml.XML.loadString(responseBody.replace("hide-me", "########"))
+      scala.xml.XML.loadString(
+        dataEvent.request.detail(RequestBody)
+      ) shouldBe scala.xml.XML.loadString(
+        requestBody.replace("hide-me", "########")
+      )
+      scala.xml.XML.loadString(
+        dataEvent.response.detail(ResponseMessage)
+      ) shouldBe scala.xml.XML.loadString(
+        responseBody.replace("hide-me", "########")
+      )
 
-      dataEvent.redactionLog.redactedFields shouldBe List("request.detail.requestBody", "response.detail.responseMessage")
+      dataEvent.redactionLog.redactedFields shouldBe List(
+        "request.detail.requestBody",
+        "response.detail.responseMessage"
+      )
     }
 
     "handle an invalid xml request and response body" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val requestBody  = "< this is not xml"
       val responseBody = "< this is also not xml"
 
       val response = ResponseData(
-        body    = Data.pure(responseBody),
-        status  = 200,
+        body = Data.pure(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -495,24 +604,29 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      dataEvent.request.detail(RequestBody)      shouldBe requestBody
+      dataEvent.request.detail(RequestBody) shouldBe requestBody
       dataEvent.response.detail(ResponseMessage) shouldBe responseBody
     }
 
     "handle an invalid json request and response body" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val requestBody  = "{ not json"
       val responseBody = "{ also not json"
 
       val response = ResponseData(
-        body    = Data.pure(responseBody),
-        status  = 200,
+        body = Data.pure(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -520,24 +634,29 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      dataEvent.request.detail(RequestBody)      shouldBe requestBody
+      dataEvent.request.detail(RequestBody) shouldBe requestBody
       dataEvent.response.detail(ResponseMessage) shouldBe responseBody
     }
 
     "indicate if the request body was truncated" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val requestBody = "truncated body"
 
       val responseBody = "complete body"
-      val response = ResponseData(
-        body    = Data.pure(responseBody),
-        status  = 200,
+      val response     = ResponseData(
+        body = Data.pure(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.truncated(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.truncated(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -545,25 +664,32 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      dataEvent.request.detail(RequestBody)      shouldBe requestBody
-      dataEvent.truncationLog.truncatedFields    shouldBe List("request.detail.requestBody")
+      dataEvent.request.detail(RequestBody) shouldBe requestBody
+      dataEvent.truncationLog.truncatedFields shouldBe List(
+        "request.detail.requestBody"
+      )
       dataEvent.response.detail(ResponseMessage) shouldBe responseBody
     }
 
     "indicate if the response body was truncated" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val requestBody = "complete body"
 
       val responseBody = "truncated body"
-      val response = ResponseData(
-        body    = Data.truncated(responseBody),
-        status  = 200,
+      val response     = ResponseData(
+        body = Data.truncated(responseBody),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(postVerb, serviceUri, Seq.empty, Some(Data.pure(HookData.FromString(requestBody))))
+      val request = httpWithAudit.buildRequest(
+        postVerb,
+        serviceUri,
+        Seq.empty,
+        Some(Data.pure(HookData.FromString(requestBody)))
+      )
 
       whenAuditSuccess(connector)
 
@@ -571,14 +697,24 @@ class HttpAuditingSpec
 
       val dataEvent = verifyAndRetrieveEvent(connector)
 
-      dataEvent.request.detail(RequestBody)      shouldBe requestBody
+      dataEvent.request.detail(RequestBody) shouldBe requestBody
       dataEvent.response.detail(ResponseMessage) shouldBe responseBody
-      dataEvent.truncationLog.truncatedFields    shouldBe List("response.detail.responseMessage")
+      dataEvent.truncationLog.truncatedFields shouldBe List(
+        "response.detail.responseMessage"
+      )
     }
   }
 
   "Calling an internal microservice" should {
-    val auditUris = Seq("service", "public.mdtp", "protected.mdtp", "private.mdtp", "monolith.mdtp", "foobar.mdtp", "mdtp").map { zone =>
+    val auditUris = Seq(
+      "service",
+      "public.mdtp",
+      "protected.mdtp",
+      "private.mdtp",
+      "monolith.mdtp",
+      "foobar.mdtp",
+      "mdtp"
+    ).map { zone =>
       s"http://auth.$zone:80/auth/authority"
     }
     val getVerb = "GET"
@@ -592,12 +728,13 @@ class HttpAuditingSpec
         val requestBody   = None
 
         val response = ResponseData(
-          body    = Data.pure("the response body"),
-          status  = 200,
+          body = Data.pure("the response body"),
+          status = 200,
           headers = Map.empty
         )
 
-        val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+        val request =
+          httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
 
         httpWithAudit.audit(request, Right(response))
 
@@ -611,8 +748,12 @@ class HttpAuditingSpec
         val httpWithAudit = new HttpWithAuditing(connector)
         val requestBody   = None
 
-        val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
-        httpWithAudit.audit(request, Left("An exception occurred when calling sendevent datastream"))
+        val request =
+          httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+        httpWithAudit.audit(
+          request,
+          Left("An exception occurred when calling sendevent datastream")
+        )
 
         verifyNoMoreInteractions(connector)
       }
@@ -630,12 +771,13 @@ class HttpAuditingSpec
       val requestBody   = None
 
       val response = ResponseData(
-        body    = Data.pure("the response body"),
-        status  = 200,
+        body = Data.pure("the response body"),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+      val request =
+        httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
 
       whenAuditSuccess(connector)
 
@@ -659,12 +801,13 @@ class HttpAuditingSpec
       val requestBody   = None
 
       val response = ResponseData(
-        body    = Data.pure("the response body"),
-        status  = 200,
+        body = Data.pure("the response body"),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+      val request =
+        httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
 
       httpWithAudit.audit(request, Right(response))
 
@@ -676,8 +819,12 @@ class HttpAuditingSpec
       val httpWithAudit = new HttpWithAuditing(connector)
       val requestBody   = None
 
-      val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
-      httpWithAudit.audit(request, Left("An exception occurred when calling sendevent datastream"))
+      val request =
+        httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+      httpWithAudit.audit(
+        request,
+        Left("An exception occurred when calling sendevent datastream")
+      )
 
       verifyNoMoreInteractions(connector)
     }
@@ -694,25 +841,30 @@ class HttpAuditingSpec
       val requestBody   = None
 
       val response = ResponseData(
-        body    = Data.pure("the response body"),
-        status  = 200,
+        body = Data.pure("the response body"),
+        status = 200,
         headers = Map.empty
       )
 
-      val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+      val request =
+        httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
 
       httpWithAudit.audit(request, Right(response))
 
       verifyNoMoreInteractions(connector)
     }
 
-    "not generate an audit event when an exception has been thrown" in  {
+    "not generate an audit event when an exception has been thrown" in {
       val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
       val requestBody   = None
 
-      val request = httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
-      httpWithAudit.audit(request, Left("An exception occured when calling sendevent datastream"))
+      val request =
+        httpWithAudit.buildRequest(getVerb, auditUri, Seq.empty, requestBody)
+      httpWithAudit.audit(
+        request,
+        Left("An exception occured when calling sendevent datastream")
+      )
 
       verifyNoMoreInteractions(connector)
     }
@@ -731,7 +883,7 @@ class HttpAuditingSpec
     }
 
     "treat keys in a case insensitive way when returning values" in {
-      val connector = mock[AuditConnector]
+      val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
       val headers = Seq(
@@ -771,7 +923,9 @@ class HttpAuditingSpec
       val connector     = mock[AuditConnector]
       val httpWithAudit = new HttpWithAuditing(connector)
 
-      Future.traverse((0 to 1000))(_ => Future { httpWithAudit.maskString("<xml>a</xml>") }).futureValue shouldBe {
+      Future
+        .traverse((0 to 1000))(_ => Future { httpWithAudit.maskString("<xml>a</xml>") })
+        .futureValue shouldBe {
         (0 to 1000).map(_ => Data.pure("<xml>a</xml>"))
       }
     }
@@ -783,10 +937,10 @@ class HttpAuditingSpec
     override def auditConnector: AuditConnector = connector
 
     def auditRequestWithResponseF(
-      verb     : String,
-      url      : String,
-      request  : RequestData,
-      responseF: Future[ResponseData]
+        verb: String,
+        url: String,
+        request: RequestData,
+        responseF: Future[ResponseData]
     )(implicit hc: HeaderCarrier): Unit =
       AuditingHook(verb, url"$url", request, responseF)(hc, global)
 
@@ -798,19 +952,32 @@ class HttpAuditingSpec
       else
         responseDateTime
 
-    def buildRequest(verb: String, url: String, headers: Seq[(String, String)], body: Option[Data[HookData]]): HttpRequest = {
+    def buildRequest(
+        verb: String,
+        url: String,
+        headers: Seq[(String, String)],
+        body: Option[Data[HookData]]
+    ): HttpRequest = {
       returnNowForRequest.set(false)
       HttpRequest(verb, url, headers, body, requestDateTime)
     }
   }
 
   def whenAuditSuccess(connector: AuditConnector): Unit =
-    when(connector.sendMergedEvent(any[MergedDataEvent])(any[HeaderCarrier], any[ExecutionContext]))
+    when(
+      connector.sendMergedEvent(any[MergedDataEvent])(
+        any[HeaderCarrier],
+        any[ExecutionContext]
+      )
+    )
       .thenReturn(Future.successful(AuditResult.Success))
 
   def verifyAndRetrieveEvent(connector: AuditConnector): MergedDataEvent = {
     val captor = ArgumentCaptor.forClass(classOf[MergedDataEvent])
-    verify(connector).sendMergedEvent(captor.capture())(any[HeaderCarrier], any[ExecutionContext])
+    verify(connector).sendMergedEvent(captor.capture())(
+      any[HeaderCarrier],
+      any[ExecutionContext]
+    )
     captor.getValue
   }
 }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfigSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/config/AuditingConfigSpec.scala
@@ -35,11 +35,11 @@ class AuditingConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       )
 
       AuditingConfig.fromConfig(config) shouldBe AuditingConfig(
-        consumer         = Some(Consumer(BaseUri("localhost", 8100, "http"))),
-        enabled          = true,
-        auditSource      = "app-name",
+        consumer = Some(Consumer(BaseUri("localhost", 8100, "http"))),
+        enabled = true,
+        auditSource = "app-name",
         auditSentHeaders = false,
-        auditProvider    = Some("audit-provider")
+        auditProvider = Some("audit-provider")
       )
     }
 
@@ -49,9 +49,9 @@ class AuditingConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       )
 
       AuditingConfig.fromConfig(config) shouldBe AuditingConfig(
-        consumer         = None,
-        enabled          = false,
-        auditSource      = "auditing disabled",
+        consumer = None,
+        enabled = false,
+        auditSource = "auditing disabled",
         auditSentHeaders = false
       )
     }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditChannelSpec.scala
@@ -34,34 +34,38 @@ import uk.gov.hmrc.play.audit.http.config.{AuditingConfig, BaseUri, Consumer}
 import scala.concurrent.ExecutionContext
 
 class AuditChannelSpec
-  extends AnyWordSpec
-     with Matchers
-     with ScalaFutures
-     with IntegrationPatience
-     with MockitoSugar
-     with OneInstancePerTest {
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with MockitoSugar
+    with OneInstancePerTest {
 
   implicit val ec: ExecutionContext = RunInlineExecutionContext
   implicit val as: ActorSystem      = ActorSystem()
 
-  private def createAuditChannel(config: AuditingConfig): AuditChannel = new AuditChannel with DatastreamMetricsMock {
-    override def auditingConfig   : AuditingConfig       = config
-    override def materializer     : Materializer         = implicitly
-    override def lifecycle        : ApplicationLifecycle = new DefaultApplicationLifecycle()
-    override def datastreamMetrics: DatastreamMetrics    = mockDatastreamMetrics(Some("play.the-project-name"))
-  }
+  private def createAuditChannel(config: AuditingConfig): AuditChannel =
+    new AuditChannel with DatastreamMetricsMock {
+      override def auditingConfig: AuditingConfig  = config
+      override def materializer: Materializer      = implicitly
+      override def lifecycle: ApplicationLifecycle =
+        new DefaultApplicationLifecycle()
+      override def datastreamMetrics: DatastreamMetrics = mockDatastreamMetrics(
+        Some("play.the-project-name")
+      )
+    }
 
   "AuditConnector" should {
     "post data to datastream" in {
       val testPort = WireMockUtils.availablePort()
       val consumer = Consumer(BaseUri("localhost", testPort, "http"))
-      val config = AuditingConfig(
-        consumer         = Some(consumer),
-        enabled          = true,
-        auditSource      = "the-project-name",
+      val config   = AuditingConfig(
+        consumer = Some(consumer),
+        enabled = true,
+        auditSource = "the-project-name",
         auditSentHeaders = false
       )
-      val channel = createAuditChannel(config)
+      val channel  = createAuditChannel(config)
       val wireMock = new WireMockServer(testPort)
       WireMock.configureFor("localhost", testPort)
       wireMock.start()
@@ -69,7 +73,8 @@ class AuditChannelSpec
       WireMock.stubFor(
         post(urlPathEqualTo("/write/audit"))
           .withRequestBody(containing("TEST_DATA"))
-          .willReturn(aResponse().withStatus(204)))
+          .willReturn(aResponse().withStatus(204))
+      )
 
       channel.send("/write/audit", Json.obj("test" -> "TEST_DATA")).futureValue
       WireMock.verify(1, postRequestedFor(urlPathEqualTo("/write/audit")))

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -301,7 +301,6 @@ class AuditConnectorSpec
     )
 
     "call AuditChannel.send with tags read from headerCarrier and serialize T" in {
-      val writes = Json.writes[MyExampleAudit]
 
       createConnector(enabledConfig).sendExplicitAudit(
         "theAuditType",
@@ -323,11 +322,10 @@ class AuditConnectorSpec
     }
 
     "add auditProvider if specified in config" in {
-      val writes = Json.writes[MyExampleAudit]
 
       createConnector(enabledConfigWithProvider).sendExplicitAudit(
         "theAuditType",
-        MyExampleAudit("Agent", "123")
+        Subscription("name", 40, List("list"), Set("Set"), Address("street", "postcode"))
       )
 
       verifyAuditProviderIs("config-provider")

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -42,9 +42,9 @@ import uk.gov.hmrc.play.audit.model.ValidatedDataEvent
 @CipAuditEventUnvalidated
 case class MyExampleAudit(userType: String, vrn: String)
 
-object MyExampleAudit:
+object MyExampleAudit{
   implicit val format: AuditFormat[MyExampleAudit] = JsonValidatorMacro.nonvalidatedFormat
-
+}
 class AuditConnectorSpec
     extends AnyWordSpec
     with Matchers

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -37,6 +37,7 @@ import play.api.libs.json.OFormat
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
 import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
+import uk.gov.hmrc.play.audit.model.ValidatedDataEvent
 
 @CipAuditEventUnvalidated
 case class MyExampleAudit(userType: String, vrn: String)
@@ -205,6 +206,23 @@ class AuditConnectorSpec
     }
   }
 
+  "sendValidatedEvent" should {
+    val subscription =
+      Subscription("John", 25, List("one"), Set("two"), Address("nowhere avenue", "AB12 3CD", Option("UK")))
+
+    val validatedEvent = ValidatedDataEvent("source", "type", detail = subscription)
+
+    "send a validated event" in {
+      createConnector(enabledConfig).sendValidatedEvent(validatedEvent).futureValue shouldBe AuditResult.Success
+
+      val captor = ArgumentCaptor.forClass(classOf[JsValue])
+
+      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
+
+      // val capturedValue = captor.getValue()
+    }
+  }
+
   "sendExtendedEvent" should {
     val detail = Json.parse(
       """{"some-event": "value", "some-other-event": "other-value"}"""
@@ -325,7 +343,7 @@ class AuditConnectorSpec
 
       createConnector(enabledConfigWithProvider).sendExplicitAudit(
         "theAuditType",
-        Subscription("name", 40, List("list"), Set("Set"), Address("street", "postcode"))
+        Subscription("name", 40, List("list"), Set("Set"), Address("street", "postcode", None))
       )
 
       verifyAuditProviderIs("config-provider")

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -33,17 +33,25 @@ import uk.gov.hmrc.play.audit.http.config.{AuditingConfig, BaseUri, Consumer}
 import uk.gov.hmrc.play.audit.http.connector.AuditResult._
 import uk.gov.hmrc.play.audit.model.{DataCall, DataEvent, ExtendedDataEvent, MergedDataEvent}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.audit.http.validation.AuditFormat
+import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
+import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
 
+@CipAuditEventUnvalidated
 case class MyExampleAudit(userType: String, vrn: String)
 
+object MyExampleAudit:
+  implicit val format: AuditFormat[MyExampleAudit] = JsonValidatorMacro.nonvalidatedFormat
+
 class AuditConnectorSpec
-  extends AnyWordSpec
-     with Matchers
-     with ScalaFutures
-     with IntegrationPatience
-     with MockitoSugar
-     with OneInstancePerTest
-     with DatastreamMetricsMock {
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with MockitoSugar
+    with OneInstancePerTest
+    with DatastreamMetricsMock {
 
   implicit val ec: ExecutionContext = RunInlineExecutionContext
   implicit val as: ActorSystem      = ActorSystem()
@@ -51,18 +59,22 @@ class AuditConnectorSpec
   private val consumer = Consumer(BaseUri("datastream-base-url", 8080, "http"))
 
   private val enabledConfig = AuditingConfig(
-    consumer         = Some(consumer),
-    enabled          = true,
-    auditSource      = "the-project-name",
+    consumer = Some(consumer),
+    enabled = true,
+    auditSource = "the-project-name",
     auditSentHeaders = false
   )
-  private val enabledConfigWithProvider = enabledConfig.copy(auditProvider = Some("config-provider"))
+  private val enabledConfigWithProvider =
+    enabledConfig.copy(auditProvider = Some("config-provider"))
 
   private val mockAuditChannel: AuditChannel = mock[AuditChannel]
   when(mockAuditChannel.send(any[String], any[JsValue])(any[ExecutionContext]))
     .thenReturn(Future.successful(HandlerResult.Success))
 
-  private def createConnector(config: AuditingConfig, metricsKey: Option[String] = Some("play.the-project-name")): AuditConnector =
+  private def createConnector(
+      config: AuditingConfig,
+      metricsKey: Option[String] = Some("play.the-project-name")
+  ): AuditConnector =
     new AuditConnector {
       override def auditingConfig    = config
       override def auditChannel      = mockAuditChannel
@@ -71,34 +83,45 @@ class AuditConnectorSpec
 
   "sendMergedEvent" should {
     val mergedEvent = MergedDataEvent(
-      auditSource   = "source",
-      auditType     = "type",
-      eventId       = "TestEventId",
-      request       = DataCall(Map.empty, Map.empty, Instant.now()),
-      response      = DataCall(Map.empty, Map.empty, Instant.now())
+      auditSource = "source",
+      auditType = "type",
+      eventId = "TestEventId",
+      request = DataCall(Map.empty, Map.empty, Instant.now()),
+      response = DataCall(Map.empty, Map.empty, Instant.now())
     )
-    val mergedEventWithProvider = mergedEvent.copy(auditProvider = Some("event-provider"))
+    val mergedEventWithProvider =
+      mergedEvent.copy(auditProvider = Some("event-provider"))
 
     "call merged Datastream with event converted to json" in {
-      createConnector(enabledConfig).sendMergedEvent(mergedEvent).futureValue shouldBe Success
+      createConnector(enabledConfig)
+        .sendMergedEvent(mergedEvent)
+        .futureValue shouldBe Success
 
-      verify(mockAuditChannel).send(any[String], any[JsValue])(any[ExecutionContext])
+      verify(mockAuditChannel).send(any[String], any[JsValue])(
+        any[ExecutionContext]
+      )
     }
 
     "add auditProvider if specified in the event" in {
-      createConnector(enabledConfig).sendMergedEvent(mergedEventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendMergedEvent(mergedEventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
 
     "add auditProvider if specified in config" in {
-      createConnector(enabledConfigWithProvider).sendMergedEvent(mergedEvent).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendMergedEvent(mergedEvent)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("config-provider")
     }
 
     "add auditProvider from the event if specified in config and the event" in {
-      createConnector(enabledConfigWithProvider).sendMergedEvent(mergedEventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendMergedEvent(mergedEventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
@@ -106,190 +129,244 @@ class AuditConnectorSpec
 
   "sendEvent" should {
     val event             = DataEvent(auditSource = "source", auditType = "type")
-    val eventWithProvider = DataEvent(auditProvider = Some("event-provider"), auditSource = "source", auditType = "type")
+    val eventWithProvider = DataEvent(
+      auditProvider = Some("event-provider"),
+      auditSource = "source",
+      auditType = "type"
+    )
 
     "call AuditChannel.send with the event converted to json" in {
-      createConnector(enabledConfig).sendEvent(event).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendEvent(event)
+        .futureValue shouldBe AuditResult.Success
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "auditProvider").isDefined  shouldBe false
-      (captor.getValue \ "auditSource"  ).as[String] shouldBe "source"
-      (captor.getValue \ "auditType"    ).as[String] shouldBe "type"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "auditProvider").isDefined shouldBe false
+      (captor.getValue \ "auditSource").as[String] shouldBe "source"
+      (captor.getValue \ "auditType").as[String] shouldBe "type"
     }
 
     "add auditProvider if specified in the event" in {
-      createConnector(enabledConfig).sendEvent(eventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendEvent(eventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
 
     "add auditProvider if specified in config" in {
-      createConnector(enabledConfigWithProvider).sendEvent(event).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendEvent(event)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("config-provider")
     }
 
     "add auditProvider from the event if specified in config and the event" in {
-      createConnector(enabledConfigWithProvider).sendEvent(eventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendEvent(eventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
 
     "add tags if not specified" in {
-      val headerCarrier = HeaderCarrier(sessionId = Some(SessionId("session-123")))
+      val headerCarrier =
+        HeaderCarrier(sessionId = Some(SessionId("session-123")))
 
-      createConnector(enabledConfig).sendEvent(event)(headerCarrier, ec).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendEvent(event)(headerCarrier, ec)
+        .futureValue shouldBe AuditResult.Success
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "tags" \ "X-Session-ID").as[String] shouldBe "session-123"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "tags" \ "X-Session-ID")
+        .as[String] shouldBe "session-123"
     }
 
     "return Disabled if auditing is not enabled" in {
       val disabledConfig = AuditingConfig(
-        consumer    = Some(Consumer(BaseUri("datastream-base-url", 8080, "http"))),
-        enabled     = false,
+        consumer = Some(Consumer(BaseUri("datastream-base-url", 8080, "http"))),
+        enabled = false,
         auditSource = "the-project-name",
         auditSentHeaders = false
       )
 
-      createConnector(disabledConfig).sendEvent(event).futureValue shouldBe AuditResult.Disabled
+      createConnector(disabledConfig)
+        .sendEvent(event)
+        .futureValue shouldBe AuditResult.Disabled
 
       verifyNoMoreInteractions(mockAuditChannel)
     }
   }
 
   "sendExtendedEvent" should {
-    val detail            = Json.parse("""{"some-event": "value", "some-other-event": "other-value"}""")
-    val event             = ExtendedDataEvent(auditSource = "source", auditType = "type", detail = detail)
+    val detail = Json.parse(
+      """{"some-event": "value", "some-other-event": "other-value"}"""
+    )
+    val event = ExtendedDataEvent(
+      auditSource = "source",
+      auditType = "type",
+      detail = detail
+    )
     val eventWithProvider = event.copy(auditProvider = Some("event-provider"))
 
     "call AuditChannel.send with extended event data converted to json" in {
-      createConnector(enabledConfig).sendExtendedEvent(event).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendExtendedEvent(event)
+        .futureValue shouldBe AuditResult.Success
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "auditProvider"          ).isDefined shouldBe false
-      (captor.getValue \ "auditSource"            ).as[String] shouldBe "source"
-      (captor.getValue \ "auditType"              ).as[String] shouldBe "type"
-      (captor.getValue \ "metadata" \ "metricsKey").as[String] shouldBe "play.the-project-name"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "auditProvider").isDefined shouldBe false
+      (captor.getValue \ "auditSource").as[String] shouldBe "source"
+      (captor.getValue \ "auditType").as[String] shouldBe "type"
+      (captor.getValue \ "metadata" \ "metricsKey")
+        .as[String] shouldBe "play.the-project-name"
     }
 
     "add auditProvider if specified in the event" in {
-      createConnector(enabledConfig).sendExtendedEvent(eventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfig)
+        .sendExtendedEvent(eventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
 
     "add auditProvider if specified in config" in {
-      createConnector(enabledConfigWithProvider).sendExtendedEvent(event).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendExtendedEvent(event)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("config-provider")
     }
 
     "add auditProvider from the event if specified in the event and config" in {
-      createConnector(enabledConfigWithProvider).sendExtendedEvent(eventWithProvider).futureValue shouldBe AuditResult.Success
+      createConnector(enabledConfigWithProvider)
+        .sendExtendedEvent(eventWithProvider)
+        .futureValue shouldBe AuditResult.Success
 
       verifyAuditProviderIs("event-provider")
     }
   }
 
   "sendExplicitEvent Map[String,String]" should {
-    val headerCarrier = HeaderCarrier(sessionId = Some(SessionId("session-123")), otherHeaders = Seq("path" -> "/a/b/c"))
+    val headerCarrier = HeaderCarrier(
+      sessionId = Some(SessionId("session-123")),
+      otherHeaders = Seq("path" -> "/a/b/c")
+    )
 
     "call AuditChannel.send with tags read from headerCarrier" in {
-      createConnector(enabledConfig).sendExplicitAudit("theAuditType", Map("a" -> "1"))(headerCarrier, ec)
+      createConnector(enabledConfig).sendExplicitAudit(
+        "theAuditType",
+        Map("a" -> "1")
+      )(headerCarrier, ec)
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "auditSource"            ).as[String]             shouldBe "the-project-name"
-      (captor.getValue \ "tags" \ "X-Session-ID"  ).as[String]             shouldBe "session-123"
-      (captor.getValue \ "tags" \ "path"          ).as[String]             shouldBe "/a/b/c"
-      (captor.getValue \ "detail"                 ).as[Map[String,String]] shouldBe Map("a" -> "1")
-      (captor.getValue \ "metadata" \ "metricsKey").as[String]             shouldBe "play.the-project-name"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "auditSource").as[String] shouldBe "the-project-name"
+      (captor.getValue \ "tags" \ "X-Session-ID")
+        .as[String] shouldBe "session-123"
+      (captor.getValue \ "tags" \ "path").as[String] shouldBe "/a/b/c"
+      (captor.getValue \ "detail").as[Map[String, String]] shouldBe Map(
+        "a" -> "1"
+      )
+      (captor.getValue \ "metadata" \ "metricsKey")
+        .as[String] shouldBe "play.the-project-name"
     }
 
     "add auditProvider if specified in config" in {
-      createConnector(enabledConfigWithProvider).sendExplicitAudit("theAuditType", Map("a" -> "1"))(headerCarrier, ec)
+      createConnector(enabledConfigWithProvider).sendExplicitAudit(
+        "theAuditType",
+        Map("a" -> "1")
+      )(headerCarrier, ec)
 
       verifyAuditProviderIs("config-provider")
     }
   }
 
   "sendExplicitEvent [T]" should {
-    val headerCarrier = HeaderCarrier(sessionId = Some(SessionId("session-123")), otherHeaders = Seq("path" -> "/a/b/c"))
+    given HeaderCarrier(
+      sessionId = Some(SessionId("session-123")),
+      otherHeaders = Seq("path" -> "/a/b/c")
+    )
 
     "call AuditChannel.send with tags read from headerCarrier and serialize T" in {
       val writes = Json.writes[MyExampleAudit]
 
-      createConnector(enabledConfig).sendExplicitAudit("theAuditType", MyExampleAudit("Agent","123"))(headerCarrier, ec, writes)
+      createConnector(enabledConfig).sendExplicitAudit(
+        "theAuditType",
+        MyExampleAudit("Agent", "123")
+      )
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "auditSource"            ).as[String] shouldBe "the-project-name"
-      (captor.getValue \ "tags" \ "X-Session-ID"  ).as[String] shouldBe "session-123"
-      (captor.getValue \ "tags" \ "path"          ).as[String] shouldBe "/a/b/c"
-      (captor.getValue \ "detail" \ "userType"    ).as[String] shouldBe "Agent"
-      (captor.getValue \ "detail" \ "vrn"         ).as[String] shouldBe "123"
-      (captor.getValue \ "metadata" \ "metricsKey").as[String] shouldBe "play.the-project-name"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "auditSource").as[String] shouldBe "the-project-name"
+      (captor.getValue \ "tags" \ "X-Session-ID")
+        .as[String] shouldBe "session-123"
+      (captor.getValue \ "tags" \ "path").as[String] shouldBe "/a/b/c"
+      (captor.getValue \ "detail" \ "userType").as[String] shouldBe "Agent"
+      (captor.getValue \ "detail" \ "vrn").as[String] shouldBe "123"
+      (captor.getValue \ "metadata" \ "metricsKey")
+        .as[String] shouldBe "play.the-project-name"
     }
 
     "add auditProvider if specified in config" in {
       val writes = Json.writes[MyExampleAudit]
 
-      createConnector(enabledConfigWithProvider).sendExplicitAudit("theAuditType", MyExampleAudit("Agent","123"))(headerCarrier, ec, writes)
-
-      verifyAuditProviderIs("config-provider")
-    }
-  }
-
-  "sendExplicitEvent JsObject" should {
-    val expectedDetail = Json.obj("Address" -> Json.obj("line1" -> "Road", "postCode" -> "123"))
-    val headerCarrier  = HeaderCarrier(sessionId = Some(SessionId("session-123")), otherHeaders = Seq("path" -> "/a/b/c"))
-
-    "call AuditChannel.send with tags read from headerCarrier and pass through detail" in {
-      createConnector(enabledConfig).sendExplicitAudit("theAuditType", expectedDetail)(headerCarrier, ec)
-
-      val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "auditSource"            ).as[String]   shouldBe "the-project-name"
-      (captor.getValue \ "tags" \ "X-Session-ID"  ).as[String]   shouldBe "session-123"
-      (captor.getValue \ "tags" \ "path"          ).as[String]   shouldBe "/a/b/c"
-      (captor.getValue \ "detail"                 ).as[JsObject] shouldBe expectedDetail
-      (captor.getValue \ "metadata" \ "metricsKey").as[String]   shouldBe "play.the-project-name"
-    }
-
-    "add auditProvider if specified" in {
-      createConnector(enabledConfigWithProvider).sendExplicitAudit("theAuditType", expectedDetail)(headerCarrier, ec)
+      createConnector(enabledConfigWithProvider).sendExplicitAudit(
+        "theAuditType",
+        MyExampleAudit("Agent", "123")
+      )
 
       verifyAuditProviderIs("config-provider")
     }
   }
 
   "send" should {
-    val expectedDetail = Json.obj("Address" -> Json.obj("line1" -> "Road", "postCode" -> "123"))
+    val expectedDetail =
+      Json.obj("Address" -> Json.obj("line1" -> "Road", "postCode" -> "123"))
 
     "provide metricsKey metadata if available" in {
-      createConnector(enabledConfig, Some("play.the-project-name")).send("theAuditType", expectedDetail)(ec)
+      createConnector(enabledConfig, Some("play.the-project-name"))
+        .send("theAuditType", expectedDetail)(ec)
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-      (captor.getValue \ "metadata" \ "metricsKey").as[String] shouldBe "play.the-project-name"
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
+      (captor.getValue \ "metadata" \ "metricsKey")
+        .as[String] shouldBe "play.the-project-name"
     }
 
     "provide null in metadata if metricsKey is not available" in {
-      createConnector(enabledConfig, metricsKey = None).send("theAuditType", expectedDetail)(ec)
+      createConnector(enabledConfig, metricsKey = None)
+        .send("theAuditType", expectedDetail)(ec)
 
       val captor = ArgumentCaptor.forClass(classOf[JsValue])
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
+      verify(mockAuditChannel).send(any[String], captor.capture())(
+        any[ExecutionContext]
+      )
       (captor.getValue \ "metadata" \ "metricsKey").as[JsValue] shouldBe JsNull
     }
   }
 
   private def verifyAuditProviderIs(auditProvider: String): Unit = {
     val captor = ArgumentCaptor.forClass(classOf[JsValue])
-    verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
+    verify(mockAuditChannel).send(any[String], captor.capture())(
+      any[ExecutionContext]
+    )
     (captor.getValue \ "auditProvider").as[String] shouldBe auditProvider
   }
 }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnectorSpec.scala
@@ -35,15 +35,15 @@ import uk.gov.hmrc.play.audit.model.{DataCall, DataEvent, ExtendedDataEvent, Mer
 import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json.OFormat
 import uk.gov.hmrc.play.audit.http.validation.AuditFormat
-import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
 import uk.gov.hmrc.audit.http.validation.CipAuditEventUnvalidated
 import uk.gov.hmrc.play.audit.model.ValidatedDataEvent
+import uk.gov.hmrc.play.audit.http.validation.AuditEventSchema
 
 @CipAuditEventUnvalidated
 case class MyExampleAudit(userType: String, vrn: String)
 
 object MyExampleAudit{
-  implicit val format: AuditFormat[MyExampleAudit] = JsonValidatorMacro.nonvalidatedFormat
+  implicit val format: AuditFormat[MyExampleAudit] = AuditEventSchema.unvalidatedFormat
 }
 class AuditConnectorSpec
     extends AnyWordSpec
@@ -206,23 +206,6 @@ class AuditConnectorSpec
     }
   }
 
-  "sendValidatedEvent" should {
-    val subscription =
-      Subscription("John", 25, List("one"), Set("two"), Address("nowhere avenue", "AB12 3CD", Option("UK")))
-
-    val validatedEvent = ValidatedDataEvent("source", "type", detail = subscription)
-
-    "send a validated event" in {
-      createConnector(enabledConfig).sendValidatedEvent(validatedEvent).futureValue shouldBe AuditResult.Success
-
-      val captor = ArgumentCaptor.forClass(classOf[JsValue])
-
-      verify(mockAuditChannel).send(any[String], captor.capture())(any[ExecutionContext])
-
-      // val capturedValue = captor.getValue()
-    }
-  }
-
   "sendExtendedEvent" should {
     val detail = Json.parse(
       """{"some-event": "value", "some-other-event": "other-value"}"""
@@ -313,7 +296,7 @@ class AuditConnectorSpec
   }
 
   "sendExplicitEvent [T]" should {
-    given HeaderCarrier(
+    implicit val hc =  HeaderCarrier(
       sessionId = Some(SessionId("session-123")),
       otherHeaders = Seq("path" -> "/a/b/c")
     )

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
@@ -27,21 +27,21 @@ class AuditTagsSpec extends AnyWordSpec with Matchers {
   import uk.gov.hmrc.http.HeaderNames._
   import AuditExtensions._
 
-  val authorization = Authorization("authorization")
-  val forwarded = ForwardedFor("ipAdress")
-  val sessionId = SessionId("1234567890")
-  val requestId = RequestId("0987654321")
-  val deviceId = "testDeviceId"
+  val authorization    = Authorization("authorization")
+  val forwarded        = ForwardedFor("ipAdress")
+  val sessionId        = SessionId("1234567890")
+  val requestId        = RequestId("0987654321")
+  val deviceId         = "testDeviceId"
   val akamaiReputation = AkamaiReputation("foo")
 
   "Audit TAGS" should {
     "be present" in {
       val hc = new HeaderCarrier(
-        authorization    = Some(authorization),
-        forwarded        = Some(forwarded),
-        sessionId        = Some(sessionId),
-        requestId        = Some(requestId),
-        deviceID         = Some(deviceId),
+        authorization = Some(authorization),
+        forwarded = Some(forwarded),
+        sessionId = Some(sessionId),
+        requestId = Some(requestId),
+        deviceID = Some(deviceId),
         akamaiReputation = Some(akamaiReputation)
       )
 
@@ -77,7 +77,10 @@ class AuditTagsSpec extends AnyWordSpec with Matchers {
     }
 
     "have more tags.clientIP and tags.clientPort" in {
-      val hc = HeaderCarrier(trueClientIp = Some("192.168.1.1"), trueClientPort =Some("9999"))
+      val hc = HeaderCarrier(
+        trueClientIp = Some("192.168.1.1"),
+        trueClientPort = Some("9999")
+      )
 
       val tags = hc.toAuditTags("defaultsWhenNothingSet", "/the/request/path")
 
@@ -89,11 +92,11 @@ class AuditTagsSpec extends AnyWordSpec with Matchers {
   "Audit DETAILS" should {
     "be present" in {
       val hc = new HeaderCarrier(
-        authorization    = Some(authorization),
-        forwarded        = Some(forwarded),
-        sessionId        = Some(sessionId),
-        requestId        = Some(requestId),
-        deviceID         = Some(deviceId)
+        authorization = Some(authorization),
+        forwarded = Some(forwarded),
+        sessionId = Some(sessionId),
+        requestId = Some(requestId),
+        deviceID = Some(deviceId)
       )
 
       val details = hc.toAuditDetails()
@@ -110,9 +113,15 @@ class AuditTagsSpec extends AnyWordSpec with Matchers {
     }
 
     "have more details only" in {
-      val hc = HeaderCarrier(trueClientIp = Some("192.168.1.1"), trueClientPort =Some("9999"))
+      val hc = HeaderCarrier(
+        trueClientIp = Some("192.168.1.1"),
+        trueClientPort = Some("9999")
+      )
 
-      val details = hc.toAuditDetails("more-details" -> "the details", "lots-of-details" -> "interesting info")
+      val details = hc.toAuditDetails(
+        "more-details"    -> "the details",
+        "lots-of-details" -> "interesting info"
+      )
 
       details.size shouldBe 2
 

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/RunInlineExecutionContext.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/RunInlineExecutionContext.scala
@@ -18,12 +18,11 @@ package uk.gov.hmrc.play.audit.http.connector
 
 import scala.concurrent.ExecutionContext
 
-/**
-  * Ensures tasks are run on the thread creating the future
+/** Ensures tasks are run on the thread creating the future
   *
   * This makes tests more deterministic
   */
-object RunInlineExecutionContext extends ExecutionContext  {
-  override def execute(runnable: Runnable): Unit = runnable.run()
+object RunInlineExecutionContext extends ExecutionContext {
+  override def execute(runnable: Runnable): Unit     = runnable.run()
   override def reportFailure(cause: Throwable): Unit = throw cause
 }

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
@@ -27,8 +27,9 @@ case class Subscription(name: String, age: Int, list: List[String], set: Set[Str
 
 case class Address(street: String, postcode: String, country: Option[String])
 
-object Address:
+object Address {
   implicit val format: OFormat[Address] = Json.format[Address]
-
-object Subscription:
+}
+object Subscription {
   implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]
+}

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.http.connector
+
+import uk.gov.hmrc.audit.http.validation.CipAuditEventSchema
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.audit.http.validation.JsonValidatorMacro
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.audit.http.validation.AuditFormat
+
+@CipAuditEventSchema(schemaFile = "/subscription-schema.json")
+case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
+
+case class Address(street: String, postcode: String)
+
+object Address:
+  implicit val format: OFormat[Address] = Json.format[Address]
+
+object Subscription:
+  implicit val format: AuditFormat[Subscription] = JsonValidatorMacro.generateValidatedJson[Subscription]

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/http/connector/Subscription.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.play.audit.http.validation.AuditFormat
 @CipAuditEventSchema(schemaFile = "/subscription-schema.json")
 case class Subscription(name: String, age: Int, list: List[String], set: Set[String], address: Address)
 
-case class Address(street: String, postcode: String)
+case class Address(street: String, postcode: String, country: Option[String])
 
 object Address:
   implicit val format: OFormat[Address] = Json.format[Address]

--- a/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
+++ b/play-auditing-play-30/src/test/scala/uk/gov/hmrc/play/audit/model/AuditSpec.scala
@@ -39,38 +39,46 @@ class AuditSpec extends AnyWordSpec with Matchers with Eventually with Datastrea
   class MockAudit(appName: String, connector: AuditConnector) extends Audit(appName, connector) {
     private val capturedDataEvent = new AtomicReference[DataEvent]()
 
-    override def sendDataEvent(de: DataEvent)(implicit ec: ExecutionContext): Unit =
+    override def sendDataEvent(de: DataEvent)(implicit
+        ec: ExecutionContext
+    ): Unit =
       capturedDataEvent.set(de)
 
     def verifyDataEvent(expected: DataEvent): Unit = {
       val actual = capturedDataEvent.get()
       actual.auditSource shouldBe expected.auditSource
-      actual.auditType   shouldBe expected.auditType
-      actual.tags        shouldBe expected.tags
-      actual.detail      shouldBe expected.detail
+      actual.auditType shouldBe expected.auditType
+      actual.tags shouldBe expected.tags
+      actual.detail shouldBe expected.detail
     }
   }
 
   case class AuditableEvent(transaction: String, event: String)
 
-  val transactionName = "transaction-name"
-  val inputs = Map("body" -> "request body as a string")
+  val transactionName                                = "transaction-name"
+  val inputs                                         = Map("body" -> "request body as a string")
   val transformer: OutputTransformer[AuditableEvent] =
     (auditable: AuditableEvent) =>
-      TransactionSuccess("transactionId" -> auditable.transaction, "event" -> auditable.event)
+      TransactionSuccess(
+        "transactionId" -> auditable.transaction,
+        "event"         -> auditable.event
+      )
 
-  val exampleRequestId = "12345"
-  implicit val hc: HeaderCarrier = HeaderCarrier(requestId = Some(RequestId(exampleRequestId)))
+  val exampleRequestId           = "12345"
+  implicit val hc: HeaderCarrier =
+    HeaderCarrier(requestId = Some(RequestId(exampleRequestId)))
 
   val auditConnector: AuditConnector = {
     val testconfig = AuditingConfig(
-      consumer         = Some(Consumer(BaseUri("localhost", 11111, "http"))),
-      enabled          = true,
-      auditSource      = "the-project-name",
+      consumer = Some(Consumer(BaseUri("localhost", 11111, "http"))),
+      enabled = true,
+      auditSource = "the-project-name",
       auditSentHeaders = false
     )
-    implicit val system = ActorSystem()
-    val datastreamMetricsMock = mockDatastreamMetrics(Some("play.the-project-name"))
+    implicit val system       = ActorSystem()
+    val datastreamMetricsMock = mockDatastreamMetrics(
+      Some("play.the-project-name")
+    )
 
     new AuditConnector {
       override def auditingConfig = testconfig
@@ -78,77 +86,112 @@ class AuditSpec extends AnyWordSpec with Matchers with Eventually with Datastrea
       override def datastreamMetrics = datastreamMetricsMock
 
       override def auditChannel = new AuditChannel {
-        override def auditingConfig   : AuditingConfig       = testconfig
-        override def materializer     : Materializer         = implicitly
-        override def lifecycle        : ApplicationLifecycle = new DefaultApplicationLifecycle()
-        override def datastreamMetrics: DatastreamMetrics    = datastreamMetricsMock
+        override def auditingConfig: AuditingConfig  = testconfig
+        override def materializer: Materializer      = implicitly
+        override def lifecycle: ApplicationLifecycle =
+          new DefaultApplicationLifecycle()
+        override def datastreamMetrics: DatastreamMetrics =
+          datastreamMetricsMock
       }
     }
   }
 
   "An Audit object" should {
     "be represented as an DataEvent when only passed an input" in {
-      val appName = "app-name-input-as-STRING"
+      val appName        = "app-name-input-as-STRING"
       val inputSuffixKey = ""
-      val auditable = AuditableEvent("txId1", "an event to log")
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
-      val outputs = Map("output-transactionId" -> auditable.transaction, "output-event" -> auditable.event)
+      val auditable      = AuditableEvent("txId1", "an event to log")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val outputs = Map(
+        "output-transactionId" -> auditable.transaction,
+        "output-event"         -> auditable.event
+      )
 
       val audit = new MockAudit(appName, auditConnector)
 
-      audit.as[AuditableEvent]((transactionName, "request body no key provided", transformer)) { () => auditable}
+      audit.as[AuditableEvent](
+        (transactionName, "request body no key provided", transformer)
+      ) { () => auditable }
 
       audit.verifyDataEvent(
         DataEvent(
           auditSource = appName,
-          auditType   = EventTypes.Succeeded,
-          tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-          detail      = inputs ++ outputs)
+          auditType = EventTypes.Succeeded,
+          tags = Map(
+            xRequestId        -> exampleRequestId,
+            "transactionName" -> transactionName
+          ),
+          detail = inputs ++ outputs
         )
+      )
     }
 
     "be represented as an DataEvent when passed inputs map" in {
-      val appName = "app-name-input-as-MAP"
+      val appName        = "app-name-input-as-MAP"
       val inputSuffixKey = "-event-key"
-      val auditable = AuditableEvent("txId1", "an event to log")
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
-      val outputs = Map("output-transactionId" -> auditable.transaction, "output-event" -> auditable.event)
+      val auditable      = AuditableEvent("txId1", "an event to log")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val outputs = Map(
+        "output-transactionId" -> auditable.transaction,
+        "output-event"         -> auditable.event
+      )
 
       val audit = new MockAudit(appName, auditConnector)
 
-      audit.as[AuditableEvent]((transactionName, Map("event-key" -> "request body no key provided"), transformer)) { () => auditable}
+      audit.as[AuditableEvent](
+        (
+          transactionName,
+          Map("event-key" -> "request body no key provided"),
+          transformer
+        )
+      ) { () => auditable }
 
       audit.verifyDataEvent(
         DataEvent(
           auditSource = appName,
-          auditType   = EventTypes.Succeeded,
-          tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-          detail      = inputs ++ outputs
+          auditType = EventTypes.Succeeded,
+          tags = Map(
+            xRequestId        -> exampleRequestId,
+            "transactionName" -> transactionName
+          ),
+          detail = inputs ++ outputs
         )
       )
     }
 
     "detail failure as an DataEvent" in {
-      val appName = "app-name"
+      val appName        = "app-name"
       val inputSuffixKey = ""
-      val auditable = AuditableEvent("txId1", "an event to log")
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
-      val failureReason: String = "Some error while mapping body result to transaction result"
-      val outputs = Map("transactionFailureReason" -> s"Exception Generated: $failureReason")
+      val auditable      = AuditableEvent("txId1", "an event to log")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val failureReason: String =
+        "Some error while mapping body result to transaction result"
+      val outputs = Map(
+        "transactionFailureReason" -> s"Exception Generated: $failureReason"
+      )
 
-      val audit = new MockAudit(appName, auditConnector)
-      val failingTransformer: OutputTransformer[AuditableEvent] = (_: AuditableEvent) => {
-        throw new RuntimeException(failureReason)
-      }
-      audit.as[AuditableEvent]((transactionName, "request body no key provided", failingTransformer)) { () => auditable}
+      val audit                                                 = new MockAudit(appName, auditConnector)
+      val failingTransformer: OutputTransformer[AuditableEvent] =
+        (_: AuditableEvent) => {
+          throw new RuntimeException(failureReason)
+        }
+      audit.as[AuditableEvent](
+        (transactionName, "request body no key provided", failingTransformer)
+      ) { () => auditable }
 
       eventually {
         audit.verifyDataEvent(
           DataEvent(
             auditSource = appName,
-            auditType   = EventTypes.Failed,
-            tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-            detail      = inputs ++ outputs
+            auditType = EventTypes.Failed,
+            tags = Map(
+              xRequestId        -> exampleRequestId,
+              "transactionName" -> transactionName
+            ),
+            detail = inputs ++ outputs
           )
         )
       }
@@ -157,17 +200,23 @@ class AuditSpec extends AnyWordSpec with Matchers with Eventually with Datastrea
 
   "auditing an event generated by an AsyncBody" should {
     "generate a DataEvent of type success if the body was successfully executed" in {
-      val appName = "app-name"
+      val appName        = "app-name"
       val inputSuffixKey = ""
-      val auditable = AuditableEvent("txId1", "an event to log")
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
-      val outputs = Map("output-transactionId" -> auditable.transaction, "output-event" -> auditable.event)
+      val auditable      = AuditableEvent("txId1", "an event to log")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val outputs = Map(
+        "output-transactionId" -> auditable.transaction,
+        "output-event"         -> auditable.event
+      )
 
       val audit = new MockAudit(appName, auditConnector)
 
       Await.result(
-        audit.asyncAs[AuditableEvent]((transactionName, "request body no key provided", transformer)) {
-          () => Future.successful(auditable)
+        audit.asyncAs[AuditableEvent](
+          (transactionName, "request body no key provided", transformer)
+        ) { () =>
+          Future.successful(auditable)
         },
         5.seconds
       )
@@ -176,81 +225,112 @@ class AuditSpec extends AnyWordSpec with Matchers with Eventually with Datastrea
         audit.verifyDataEvent(
           DataEvent(
             auditSource = appName,
-            auditType   = EventTypes.Succeeded,
-            tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-            detail      = inputs ++ outputs
+            auditType = EventTypes.Succeeded,
+            tags = Map(
+              xRequestId        -> exampleRequestId,
+              "transactionName" -> transactionName
+            ),
+            detail = inputs ++ outputs
           )
         )
       }
     }
 
     "generate a DataEvent of type failed if the body failed to be executed" in {
-      val appName = "app-name"
+      val appName        = "app-name"
       val inputSuffixKey = ""
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
       val failureReason: String = "Some error while invoking body"
-      val outputs = Map("transactionFailureReason" -> s"Exception Generated: $failureReason")
+      val outputs               = Map(
+        "transactionFailureReason" -> s"Exception Generated: $failureReason"
+      )
 
       val audit = new MockAudit(appName, auditConnector)
 
-      audit.asyncAs[AuditableEvent]((transactionName, "request body no key provided", transformer)) { () => Future.failed(new RuntimeException(failureReason)) }
+      audit.asyncAs[AuditableEvent](
+        (transactionName, "request body no key provided", transformer)
+      ) { () => Future.failed(new RuntimeException(failureReason)) }
 
       eventually {
         audit.verifyDataEvent(
           DataEvent(
             auditSource = appName,
-            auditType   = EventTypes.Failed,
-            tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-            detail      = inputs ++ outputs
+            auditType = EventTypes.Failed,
+            tags = Map(
+              xRequestId        -> exampleRequestId,
+              "transactionName" -> transactionName
+            ),
+            detail = inputs ++ outputs
           )
         )
       }
     }
 
     "generate a DataEvent of type failed if the body was successfully executed but the output transformer mapped the result into a failure" in {
-      val appName = "app-name"
+      val appName        = "app-name"
       val inputSuffixKey = ""
-      val auditable = AuditableEvent("txId1", "an event to log")
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
-      val failureReason = "Some error while mapping body result to transaction result"
-      val outputs = Map("transactionFailureReason" -> s"Exception Generated: $failureReason")
+      val auditable      = AuditableEvent("txId1", "an event to log")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val failureReason =
+        "Some error while mapping body result to transaction result"
+      val outputs = Map(
+        "transactionFailureReason" -> s"Exception Generated: $failureReason"
+      )
 
-      val audit = new MockAudit(appName, auditConnector)
-      val failingTransformer: OutputTransformer[AuditableEvent] = (_: AuditableEvent) => {
-        throw new RuntimeException(failureReason)
-      }
-      audit.asyncAs[AuditableEvent]((transactionName, "request body no key provided", failingTransformer)) { () => Future.successful(auditable)}
+      val audit                                                 = new MockAudit(appName, auditConnector)
+      val failingTransformer: OutputTransformer[AuditableEvent] =
+        (_: AuditableEvent) => {
+          throw new RuntimeException(failureReason)
+        }
+      audit.asyncAs[AuditableEvent](
+        (transactionName, "request body no key provided", failingTransformer)
+      ) { () => Future.successful(auditable) }
 
       eventually {
         audit.verifyDataEvent(
           DataEvent(
             auditSource = appName,
-            auditType   = EventTypes.Failed,
-            tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-            detail      = inputs ++ outputs
+            auditType = EventTypes.Failed,
+            tags = Map(
+              xRequestId        -> exampleRequestId,
+              "transactionName" -> transactionName
+            ),
+            detail = inputs ++ outputs
           )
         )
       }
     }
 
     "handle an exception thrown when the future body gets created" in {
-      val appName = "app-name"
+      val appName        = "app-name"
       val inputSuffixKey = ""
-      val inputs = Map(s"input$inputSuffixKey" -> "request body no key provided")
+      val inputs         =
+        Map(s"input$inputSuffixKey" -> "request body no key provided")
       val failureReason: String = "Some error while instantiating body future"
-      val outputs = Map("transactionFailureReason" -> s"Exception Generated: $failureReason")
+      val outputs               = Map(
+        "transactionFailureReason" -> s"Exception Generated: $failureReason"
+      )
 
-      def throwException(): Future[AuditableEvent] = throw new RuntimeException(failureReason)
+      def throwException(): Future[AuditableEvent] =
+        throw new RuntimeException(failureReason)
 
       val audit = new MockAudit(appName, auditConnector)
-      audit.asyncAs[AuditableEvent]((transactionName, "request body no key provided", transformer)) { () => throwException() }
+      audit.asyncAs[AuditableEvent](
+        (transactionName, "request body no key provided", transformer)
+      ) { () => throwException() }
 
       eventually {
-        audit.verifyDataEvent(DataEvent(
-          auditSource = appName,
-          auditType   = EventTypes.Failed,
-          tags        = Map(xRequestId -> exampleRequestId, "transactionName" -> transactionName),
-          detail      = inputs ++ outputs
+        audit.verifyDataEvent(
+          DataEvent(
+            auditSource = appName,
+            auditType = EventTypes.Failed,
+            tags = Map(
+              xRequestId        -> exampleRequestId,
+              "transactionName" -> transactionName
+            ),
+            detail = inputs ++ outputs
           )
         )
       }

--- a/project/CopyFiles.scala
+++ b/project/CopyFiles.scala
@@ -2,6 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object CopySources {
+
   /** Copies source files from one module to another, and applies transformations */
   def copySources(module: Project, transformSource: String => String, transformResource: String => String) = {
     def transformWith(fromSetting: SettingKey[File], toSetting: SettingKey[File], transform: String => String) =
@@ -9,7 +10,9 @@ object CopySources {
         val from  = fromSetting.value
         val to    = toSetting.value
         val files = (from ** "*").get.filterNot(_.isDirectory)
-        println(s"Copying and transforming the following files for ${moduleName.value} scalaVersion ${scalaVersion.value}: files:\n${files.map("  " + _).mkString("\n")}}")
+        println(
+          s"Copying and transforming the following files for ${moduleName.value} scalaVersion ${scalaVersion.value}: files:\n${files.map("  " + _).mkString("\n")}}"
+        )
         files.map { file =>
           val targetFile = new java.io.File(file.getParent.replace(from.getPath, to.getPath)) / file.getName
           IO.write(targetFile, transform(IO.read(file)))
@@ -23,13 +26,29 @@ object CopySources {
     }
 
     Seq(
-      Compile / sourceGenerators   += transformWith(module / Compile / scalaSource      , Compile / sourceManaged  , transformSource  ).taskValue,
-      Compile / resourceGenerators += transformWith(module / Compile / resourceDirectory, Compile / resourceManaged, transformResource).taskValue,
-      Test    / sourceGenerators   += transformWith(module / Test    / scalaSource      , Test    / sourceManaged  , transformSource  ).taskValue,
-      Test    / resourceGenerators += transformWith(module / Test    / resourceDirectory, Test    / resourceManaged, transformResource).taskValue,
+      Compile / sourceGenerators += transformWith(
+        module / Compile / scalaSource,
+        Compile / sourceManaged,
+        transformSource
+      ).taskValue,
+      Compile / resourceGenerators += transformWith(
+        module / Compile / resourceDirectory,
+        Compile / resourceManaged,
+        transformResource
+      ).taskValue,
+      Test / sourceGenerators += transformWith(
+        module / Test / scalaSource,
+        Test / sourceManaged,
+        transformSource
+      ).taskValue,
+      Test / resourceGenerators += transformWith(
+        module / Test / resourceDirectory,
+        Test / resourceManaged,
+        transformResource
+      ).taskValue,
       // generated sources are not included in source.jar by default
       Compile / packageSrc / mappings ++= include((Compile / sourceManaged).value) ++
-                                            include((Compile / resourceManaged).value)
+        include((Compile / resourceManaged).value)
     )
   }
 }

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -7,17 +7,18 @@ object LibDependencies {
   val httpVerbsVersion = "15.6.0"
 
   val common = Seq(
-    "org.scalatest"          %% "scalatest"               % "3.2.17"       % Test,
-    "com.vladsch.flexmark"   %  "flexmark-all"            % "0.64.8"       % Test,
-    "org.scalatestplus"      %% "scalacheck-1-17"         % "3.2.17.0"     % Test,
-    "org.scalatestplus"      %% "mockito-4-11"            % "3.2.17.0"     % Test
+    "org.scalatest"       %% "scalatest"       % "3.2.17"   % Test,
+    "com.vladsch.flexmark" % "flexmark-all"    % "0.64.8"   % Test,
+    "org.scalatestplus"   %% "scalacheck-1-17" % "3.2.17.0" % Test,
+    "org.scalatestplus"   %% "mockito-4-11"    % "3.2.17.0" % Test
   )
 
   val play30 = Seq(
-    "uk.gov.hmrc"            %% "http-verbs-play-30" % httpVerbsVersion,
-    "com.networknt"      % "json-schema-validator" % "3.0.0",
-    "org.playframework" %% "play-json"             % "3.0.6",
-    "com.github.tomakehurst" %  "wiremock"           % "3.0.0-beta-7" % Test,
-    "org.slf4j"              %  "slf4j-simple"       % "2.0.7"        % Test
+    "uk.gov.hmrc"           %% "http-verbs-play-30"    % httpVerbsVersion,
+    "com.networknt"          % "json-schema-validator" % "3.0.0",
+    "org.playframework"     %% "play-json"             % "3.0.6",
+    "io.scalaland"          %% "chimney"               % "1.8.2",
+    "com.github.tomakehurst" % "wiremock"              % "3.0.0-beta-7" % Test,
+    "org.slf4j"              % "slf4j-simple"          % "2.0.7"        % Test
   )
 }

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -1,4 +1,5 @@
-import sbt._
+import sbt.*
+import sbt.Keys.libraryDependencies
 
 object LibDependencies {
   // we depend on http-verbs just to integrate via the AuditHooks
@@ -14,6 +15,8 @@ object LibDependencies {
 
   val play30 = Seq(
     "uk.gov.hmrc"            %% "http-verbs-play-30" % httpVerbsVersion,
+    "com.networknt"      % "json-schema-validator" % "3.0.0",
+    "org.playframework" %% "play-json"             % "3.0.6",
     "com.github.tomakehurst" %  "wiremock"           % "3.0.0-beta-7" % Test,
     "org.slf4j"              %  "slf4j-simple"       % "2.0.7"        % Test
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
-resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+  Resolver.ivyStylePatterns
+)
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")


### PR DESCRIPTION
This is a PR to provide compile-time validation of audit events.

All future audit events will need a JSON Schema representation within the cip-schemas repository. Taking advantage of this, we can now add an annotation to a case class to link to the schema and validate this, at compile-time, to ensure the case class matches the schema.

**Key Points:**

1. This is a compile-time check, therefore no unit tests are required
2. AuditConnector has been modified to require a `AuditFormat[T]` which is a wrapper around `OFormat[T]`. AuditFormat can only be create after validation has passed.
3. By adding the `AuditFormat` typeclass to AuditConnector, we are ensuring developers cannot bypass this check and must use this validation

**Backwards compatibility:**
There are two cases where backwards compatibility are required:

1. When an audit event does not have a schema. This will be the case for all existing audit events
2. When a service is using Scala 2

In each case, we will have an annotation to mark a case class as unvalidated and will create an `AuditFormat[T]` for this class. Ideally, these situations should be minimal


**Note:**
I've also added scalafmt here to help with formatting